### PR TITLE
Transcribe long audio and add annotations to elan files

### DIFF
--- a/server/poetry.lock
+++ b/server/poetry.lock
@@ -175,7 +175,7 @@ graph = ["objgraph (>=1.7.2)"]
 
 [[package]]
 name = "elpis"
-version = "0.1.4"
+version = "0.1.5"
 description = "A library to perform automatic speech recognition with huggingface transformers."
 category = "main"
 optional = false
@@ -1183,8 +1183,8 @@ dill = [
     {file = "dill-0.3.5.1.tar.gz", hash = "sha256:d75e41f3eff1eee599d738e76ba8f4ad98ea229db8b085318aa2b3333a208c86"},
 ]
 elpis = [
-    {file = "elpis-0.1.4-py3-none-any.whl", hash = "sha256:a6e9d56bf713d984329e1fa568056269a9427c7d3202e4c8c3bd2360539a923d"},
-    {file = "elpis-0.1.4.tar.gz", hash = "sha256:171c305e2c30c0adffa298515fa85279f32d9d31d6ad1997ef32b89502b23506"},
+    {file = "elpis-0.1.5-py3-none-any.whl", hash = "sha256:a6b468219220b726d2dcb568abe654734980fd636baea6d25f3573d5fb1c530f"},
+    {file = "elpis-0.1.5.tar.gz", hash = "sha256:e1b98f9848d909f79f2f1452e73e37c2f3598c640fdda044936fb3ca1481a8f2"},
 ]
 exceptiongroup = [
     {file = "exceptiongroup-1.0.0rc9-py3-none-any.whl", hash = "sha256:2e3c3fc1538a094aab74fad52d6c33fc94de3dfee3ee01f187c0e0c72aec5337"},


### PR DESCRIPTION
Closes #14 
Closes #17 

This PR updates the elpis core library to a later version which has support for transcribing longer audio by breaking it into chunks in the pipeline.

It also fixes a hilarious error by me which is not adding the annotations to the elan files after transcriptions.