### PR TITLE
Clarify model training status indicator states.

### DIFF
--- a/client/src/components/train/ModelTable.tsx
+++ b/client/src/components/train/ModelTable.tsx
@@ -4,7 +4,14 @@ import {deleteModel, downloadModel, trainModel} from 'lib/api/models';
 import urls from 'lib/urls';
 import Link from 'next/link';
 import React from 'react';
-import {XCircle, Eye, Target, Download, Check} from 'react-feather';
+import {
+  XCircle,
+  Eye,
+  Target,
+  Download,
+  Check,
+  AlertTriangle,
+} from 'react-feather';
 import {modelsAtom} from 'store';
 import {TrainingStatus} from 'types/Model';
 
@@ -85,14 +92,17 @@ const ModelTable: React.FC = () => {
               </td>
               <td>{model.status}</td>
               <td>
-                {model.status !== TrainingStatus.Training &&
-                model.status !== TrainingStatus.Finished ? (
-                  <button onClick={() => _trainModel(index)}>
-                    <Target color="green" />
-                  </button>
-                ) : (
-                  <Check />
-                )}
+                <button
+                  onClick={() => _trainModel(index)}
+                  disabled={
+                    model.status === TrainingStatus.Training ||
+                    model.status === TrainingStatus.Finished
+                  }
+                >
+                  <ModelStatusIndicator
+                    status={model.status ?? TrainingStatus.Waiting}
+                  />
+                </button>
               </td>
               <td>
                 <button
@@ -120,6 +130,23 @@ const ModelTable: React.FC = () => {
       </table>
     </div>
   );
+};
+
+type Status = {
+  status: TrainingStatus;
+};
+
+const ModelStatusIndicator: React.FC<Status> = ({status}) => {
+  switch (status) {
+    case TrainingStatus.Waiting:
+      return <Target color="green" />;
+    case TrainingStatus.Training:
+      return <Target color="grey" />;
+    case TrainingStatus.Finished:
+      return <Check color="green" />;
+    case TrainingStatus.Error:
+      return <AlertTriangle color="orange" />;
+  }
 };
 
 export default ModelTable;

--- a/client/src/components/train/ModelTable.tsx
+++ b/client/src/components/train/ModelTable.tsx
@@ -109,7 +109,11 @@ const ModelTable: React.FC = () => {
                   onClick={() => download(model.modelName)}
                   disabled={model.status !== TrainingStatus.Finished}
                 >
-                  <Download />
+                  <Download
+                    color={
+                      model.status === TrainingStatus.Finished ? '#333' : '#ccc'
+                    }
+                  />
                 </button>
               </td>
               <td>
@@ -141,9 +145,9 @@ const ModelStatusIndicator: React.FC<Status> = ({status}) => {
     case TrainingStatus.Waiting:
       return <Target color="green" />;
     case TrainingStatus.Training:
-      return <Target color="grey" />;
+      return <Target color="#ccc" />;
     case TrainingStatus.Finished:
-      return <Check color="green" />;
+      return <Check color="#333" />;
     case TrainingStatus.Error:
       return <AlertTriangle color="orange" />;
   }

--- a/client/src/components/train/ModelTable.tsx
+++ b/client/src/components/train/ModelTable.tsx
@@ -11,6 +11,7 @@ import {
   Download,
   Check,
   AlertTriangle,
+  Loader,
 } from 'react-feather';
 import {modelsAtom} from 'store';
 import {TrainingStatus} from 'types/Model';
@@ -145,7 +146,7 @@ const ModelStatusIndicator: React.FC<Status> = ({status}) => {
     case TrainingStatus.Waiting:
       return <Target color="green" />;
     case TrainingStatus.Training:
-      return <Target color="#ccc" />;
+      return <Loader color="#ccc" className="animate-spin" />;
     case TrainingStatus.Finished:
       return <Check color="#333" />;
     case TrainingStatus.Error:


### PR DESCRIPTION
Closes #26 

- Show faded training symbol during model training rather than a check. 
- Show training error status as orange alert symbol.
- Fade download button if not available.

<img width="1123" alt="Screenshot 2022-11-22 at 11 52 05 am" src="https://user-images.githubusercontent.com/24891460/203197883-9cb877f0-f27c-405b-81ff-1c671c830cd3.png">
