### PR TITLE
Reduce redundant pages in flows between tasks

### DIFF
--- a/client/src/pages/datasets.tsx
+++ b/client/src/pages/datasets.tsx
@@ -38,7 +38,7 @@ const DatasetsPage: NextPage = () => {
             </a>
           </Link>
           {datasets.length > 0 && (
-            <Link href={urls.train.index}>
+            <Link href={urls.train.new}>
               <a>
                 <button className="button">Train Model</button>
               </a>

--- a/client/src/pages/train.tsx
+++ b/client/src/pages/train.tsx
@@ -51,7 +51,7 @@ const TrainPage: NextPage = () => {
               {models.filter(model => model.status === TrainingStatus.Finished)
                 .length > 0 && (
                 <div>
-                  <Link href={urls.transcriptions.index}>
+                  <Link href={urls.transcriptions.new}>
                     <a>
                       <button className="button">Transcribe Audio</button>
                     </a>


### PR DESCRIPTION
Closes #25 

Previously, when the user has created a dataset, we create a button on the dataset home page that will take them to the training home page (Train new Model). If they're going to train a new, model, why not take them directly to the new model page?

The same also applies for creating new transriptions after the user has trained a model. 
