### PR TITLE
Create basic view transcription page

### DIFF
--- a/client/src/components/transcribe/DownloadTranscriptionFileButton.tsx
+++ b/client/src/components/transcribe/DownloadTranscriptionFileButton.tsx
@@ -2,17 +2,16 @@ import {getElan, getText} from 'lib/api/transcribe';
 import fileDownload from 'js-file-download';
 import React from 'react';
 import Transcription from 'types/Transcription';
-import {Download} from 'react-feather';
 
 type Props = {
+  children: React.ReactNode;
   fileType: 'elan' | 'text';
   transcription: Transcription;
 };
 
-const DownloadTranscriptionFileButton: React.FC<Props> = ({
-  fileType,
-  transcription,
-}) => {
+const DownloadTranscriptionFileButton: React.FC<
+  Props & React.HTMLAttributes<HTMLButtonElement>
+> = ({fileType, transcription, children, ...other}) => {
   const request = fileType === 'elan' ? getElan : getText;
   const suffix = fileType === 'elan' ? '.eaf' : '.txt';
   const fileName = transcription.audioName + suffix;
@@ -33,8 +32,8 @@ const DownloadTranscriptionFileButton: React.FC<Props> = ({
   }
 
   return (
-    <button className="px-2 py-1" onClick={downloadFile}>
-      <Download />
+    <button className="px-2 py-1" {...other} onClick={downloadFile}>
+      {children}
     </button>
   );
 };

--- a/client/src/components/transcribe/TranscriptionsTable.tsx
+++ b/client/src/components/transcribe/TranscriptionsTable.tsx
@@ -1,13 +1,15 @@
 import {useAtom} from 'jotai';
 import fileDownload from 'js-file-download';
+import urls from 'lib/urls';
 import {
   deleteTranscription,
   downloadFiles,
   resetTranscriptions,
   transcribe,
 } from 'lib/api/transcribe';
+import Link from 'next/link';
 import React from 'react';
-import {Check, Target, XCircle} from 'react-feather';
+import {Check, Download, Eye, Target, XCircle} from 'react-feather';
 import {transcriptionsAtom} from 'store';
 import Transcription, {TranscriptionStatus} from 'types/Transcription';
 import DownloadTranscriptionFileButton from './DownloadTranscriptionFileButton';
@@ -152,6 +154,7 @@ const DatasetTable: React.FC = () => {
               <th>Text</th>
               <th>Elan</th>
               <th>Transcribe</th>
+              <th>View</th>
               <th>Delete</th>
             </tr>
           </thead>
@@ -166,13 +169,17 @@ const DatasetTable: React.FC = () => {
                   <DownloadTranscriptionFileButton
                     transcription={transcription}
                     fileType="text"
-                  />
+                  >
+                    <Download />
+                  </DownloadTranscriptionFileButton>
                 </td>
                 <td>
                   <DownloadTranscriptionFileButton
                     transcription={transcription}
                     fileType="elan"
-                  />
+                  >
+                    <Download />
+                  </DownloadTranscriptionFileButton>
                 </td>
 
                 <td>
@@ -186,9 +193,18 @@ const DatasetTable: React.FC = () => {
                     {transcription.status === TranscriptionStatus.Finished ? (
                       <Check />
                     ) : (
-                      <Target color="blue" />
+                      <Target color="green" />
                     )}
                   </button>
+                </td>
+                <td>
+                  <Link href={`${urls.transcriptions.view}/${index}`}>
+                    <a>
+                      <button>
+                        <Eye color="blue" />
+                      </button>
+                    </a>
+                  </Link>
                 </td>
                 <td>
                   <button

--- a/client/src/pages/transcriptions/view/[index].tsx
+++ b/client/src/pages/transcriptions/view/[index].tsx
@@ -1,0 +1,120 @@
+import DownloadTranscriptionFileButton from 'components/transcribe/DownloadTranscriptionFileButton';
+import {useAtom} from 'jotai';
+import {getText} from 'lib/api/transcribe';
+import urls from 'lib/urls';
+import Link from 'next/link';
+import {useRouter} from 'next/router';
+import React, {useEffect, useState} from 'react';
+import {Download} from 'react-feather';
+import {transcriptionsAtom} from 'store';
+import Transcription, {TranscriptionStatus} from 'types/Transcription';
+
+export default function ViewTranscriptionPage() {
+  const [transcriptions] = useAtom(transcriptionsAtom);
+  const router = useRouter();
+  const {index} = router.query;
+
+  const getTranscription = (): Transcription | undefined => {
+    if (!index) return;
+    let numberedIndex;
+    try {
+      numberedIndex = Number.parseInt(index as string);
+    } catch (err) {
+      return;
+    }
+    if (numberedIndex < 0 || numberedIndex >= transcriptions.length) {
+      return;
+    }
+    return transcriptions[numberedIndex];
+  };
+
+  const transcription = getTranscription();
+  const [text, setText] = useState('');
+
+  // Get the latest transcription text if it's finished transcribing
+  useEffect(() => {
+    const _getText = async () => {
+      if (!transcription) return;
+      if (transcription.status !== TranscriptionStatus.Finished) return;
+
+      const response = await getText(
+        transcription.modelLocation,
+        transcription.audioName
+      );
+      if (response.ok) {
+        const file = await response.blob();
+        setText(await file.text());
+      }
+    };
+
+    _getText();
+  }, [transcription, transcription?.status]);
+
+  if (!transcription) {
+    return (
+      <div className="container">
+        <h1 className="title">Transcription Not Found</h1>
+        <p>Could not find a transcription at the provided index</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="title">View Transcription</h1>
+        <Link href={urls.transcriptions.index}>
+          <a>
+            <button className="button">Back</button>
+          </a>
+        </Link>
+      </div>
+      <div className="grid grid-cols-2 section">
+        <p className="font-semibold">Model Name:</p>
+        <p>
+          {transcription.isLocal ? (
+            transcription.modelLocation
+          ) : (
+            <a
+              className="text-blue-500"
+              href={`https://huggingface.co/${transcription.modelLocation}`}
+            >
+              {transcription.modelLocation}
+            </a>
+          )}
+        </p>
+
+        <p className="font-semibold">Audio Name:</p>
+        <p>{transcription.audioName}.wav</p>
+        <p className="font-semibold">Is Local:</p>
+        <p>{transcription.isLocal ? 'True' : 'False'}</p>
+        <p className="font-semibold">Status:</p>
+        <p>{transcription.status}</p>
+      </div>
+      {transcription.status === TranscriptionStatus.Finished && (
+        <>
+          <div className="section">
+            <h2 className="font-semibold mb-2">Transcript:</h2>
+            <p className="text-gray-700">{text}</p>
+          </div>
+          <div className="flex space-x-2">
+            <DownloadTranscriptionFileButton
+              transcription={transcription}
+              fileType="text"
+              className="button"
+            >
+              Download Text
+            </DownloadTranscriptionFileButton>
+            <DownloadTranscriptionFileButton
+              transcription={transcription}
+              fileType="elan"
+              className="button"
+            >
+              Download Elan
+            </DownloadTranscriptionFileButton>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/client/src/pages/transcriptions/view/[index].tsx
+++ b/client/src/pages/transcriptions/view/[index].tsx
@@ -62,7 +62,7 @@ export default function ViewTranscriptionPage() {
   return (
     <div className="container space-y-4">
       <div className="flex items-center justify-between">
-        <h1 className="title">View Transcription</h1>
+        <h1 className="title">Transcription</h1>
         <Link href={urls.transcriptions.index}>
           <a>
             <button className="button">Back</button>


### PR DESCRIPTION
Closes #13 

- Creates a page to view transcription information for a specific transcription.
- If transcription has completed, will show transcript in the page without needing to download it (see below).

<img width="1153" alt="Screenshot 2022-11-22 at 1 59 31 pm" src="https://user-images.githubusercontent.com/24891460/203218025-f33dc648-eb63-4943-9688-3809f340ae19.png">
