### PR TITLE
Standardize delete icon and icon colours across the board.

### DIFF
--- a/client/src/components/datasets/DatasetFiles.tsx
+++ b/client/src/components/datasets/DatasetFiles.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import {filesAtom} from 'store';
 import {Trash2, Check, X, AlertTriangle} from 'react-feather';
 import {FileType, hasMatch, parseFileType} from 'lib/dataset';
+import colours from 'lib/colours';
 
 const DatasetFiles: React.FC = () => {
   const [files, setFiles] = useAtom(filesAtom);
@@ -30,14 +31,14 @@ const DatasetFiles: React.FC = () => {
             file.name,
             files.map(file => file.name)
           ) ? (
-            <Check color="green" />
+            <Check color={colours.success} />
           ) : (
-            <X color="red" />
+            <X color={colours.warning} />
           )}
         </td>
         <td>
           <button className="px-2 py-1" onClick={() => deleteFile(file.name)}>
-            <Trash2 color="red" />
+            <Trash2 color={colours.delete} />
           </button>
         </td>
       </tr>
@@ -70,7 +71,7 @@ const DatasetFiles: React.FC = () => {
       {unsupportedFiles.length > 0 && (
         <div className="mt-4 p-4 border border-orange-300 rounded">
           <div className="flex space-x-2">
-            <AlertTriangle></AlertTriangle>
+            <AlertTriangle color={colours.warning}></AlertTriangle>
             <p>Unsupported Files:</p>
           </div>
           <div className="mt-2 flex text-sm">

--- a/client/src/components/datasets/DatasetFiles.tsx
+++ b/client/src/components/datasets/DatasetFiles.tsx
@@ -2,7 +2,7 @@ import FileDropper from 'components/FileUpload';
 import {useAtom} from 'jotai';
 import React from 'react';
 import {filesAtom} from 'store';
-import {XCircle, Check, X, AlertTriangle} from 'react-feather';
+import {Trash2, Check, X, AlertTriangle} from 'react-feather';
 import {FileType, hasMatch, parseFileType} from 'lib/dataset';
 
 const DatasetFiles: React.FC = () => {
@@ -37,7 +37,7 @@ const DatasetFiles: React.FC = () => {
         </td>
         <td>
           <button className="px-2 py-1" onClick={() => deleteFile(file.name)}>
-            <XCircle color="red" />
+            <Trash2 color="red" />
           </button>
         </td>
       </tr>

--- a/client/src/components/train/DatasetTable.tsx
+++ b/client/src/components/train/DatasetTable.tsx
@@ -1,5 +1,6 @@
 import {useAtom} from 'jotai';
 import {deleteDataset} from 'lib/api/datasets';
+import colours from 'lib/colours';
 import React from 'react';
 import {Trash2} from 'react-feather';
 import {datasetsAtom} from 'store';
@@ -38,13 +39,9 @@ const DatasetTable: React.FC = () => {
               <td>{dataset.name}</td>
               <td>Local</td>
               <td>{dataset.files.length}</td>
-
               <td>
-                <button
-                  className="px-2 py-1"
-                  onClick={() => _deleteDataset(dataset.name)}
-                >
-                  <Trash2 color="#ed5e68" />
+                <button onClick={() => _deleteDataset(dataset.name)}>
+                  <Trash2 color={colours.delete} />
                 </button>
               </td>
             </tr>

--- a/client/src/components/train/DatasetTable.tsx
+++ b/client/src/components/train/DatasetTable.tsx
@@ -1,7 +1,7 @@
 import {useAtom} from 'jotai';
 import {deleteDataset} from 'lib/api/datasets';
 import React from 'react';
-import {XCircle} from 'react-feather';
+import {Trash2} from 'react-feather';
 import {datasetsAtom} from 'store';
 
 const DatasetTable: React.FC = () => {
@@ -44,7 +44,7 @@ const DatasetTable: React.FC = () => {
                   className="px-2 py-1"
                   onClick={() => _deleteDataset(dataset.name)}
                 >
-                  <XCircle color="red" />
+                  <Trash2 color="#ed5e68" />
                 </button>
               </td>
             </tr>

--- a/client/src/components/train/ModelTable.tsx
+++ b/client/src/components/train/ModelTable.tsx
@@ -1,10 +1,11 @@
 import {useAtom} from 'jotai';
 import fileDownload from 'js-file-download';
 import {deleteModel, downloadModel, trainModel} from 'lib/api/models';
+import colours from 'lib/colours';
 import urls from 'lib/urls';
 import Link from 'next/link';
 import React from 'react';
-import {XCircle, Eye, Target, Download, Check} from 'react-feather';
+import {Trash2, Eye, Download, Check, Play} from 'react-feather';
 import {modelsAtom} from 'store';
 import {TrainingStatus} from 'types/Model';
 
@@ -88,10 +89,10 @@ const ModelTable: React.FC = () => {
                 {model.status !== TrainingStatus.Training &&
                 model.status !== TrainingStatus.Finished ? (
                   <button onClick={() => _trainModel(index)}>
-                    <Target color="green" />
+                    <Play color={colours.start} />
                   </button>
                 ) : (
-                  <Check />
+                  <Check color={colours.grey} />
                 )}
               </td>
               <td>
@@ -99,19 +100,25 @@ const ModelTable: React.FC = () => {
                   onClick={() => download(model.modelName)}
                   disabled={model.status !== TrainingStatus.Finished}
                 >
-                  <Download />
+                  <Download
+                    color={
+                      model.status === TrainingStatus.Finished
+                        ? colours.grey
+                        : colours.unavailable
+                    }
+                  />
                 </button>
               </td>
               <td>
                 <Link href={urls.train.view + '/' + model.modelName}>
                   <a>
-                    <Eye color="blue" />
+                    <Eye color={colours.info} />
                   </a>
                 </Link>
               </td>
               <td>
                 <button onClick={() => _deleteModel(model.modelName)}>
-                  <XCircle color="red" />
+                  <Trash2 color={colours.delete} />
                 </button>
               </td>
             </tr>

--- a/client/src/components/transcribe/TranscriptionFileUpload.tsx
+++ b/client/src/components/transcribe/TranscriptionFileUpload.tsx
@@ -40,7 +40,7 @@ export default function TranscriptionFileUpload() {
                       {parseFileType(file.name) === FileType.Audio ? (
                         <Check color={colours.success} />
                       ) : (
-                        <X color={colours.error} />
+                        <X color={colours.warning} />
                       )}
                     </td>
                     <td>

--- a/client/src/components/transcribe/TranscriptionFileUpload.tsx
+++ b/client/src/components/transcribe/TranscriptionFileUpload.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import FileUpload from 'components/FileUpload';
 import {transcriptionFilesAtom} from 'store';
 import {useAtom} from 'jotai';
-import {Check, X, XCircle} from 'react-feather';
+import {Check, X, Trash2} from 'react-feather';
 import {FileType, parseFileType} from 'lib/dataset';
+import colours from 'lib/colours';
 
 export default function TranscriptionFileUpload() {
   const [files, setFiles] = useAtom(transcriptionFilesAtom);
@@ -37,9 +38,9 @@ export default function TranscriptionFileUpload() {
                     <td>{file.name}</td>
                     <td>
                       {parseFileType(file.name) === FileType.Audio ? (
-                        <Check color="green" />
+                        <Check color={colours.success} />
                       ) : (
-                        <X color="red" />
+                        <X color={colours.error} />
                       )}
                     </td>
                     <td>
@@ -50,7 +51,7 @@ export default function TranscriptionFileUpload() {
                           )
                         }
                       >
-                        <XCircle color="red" />
+                        <Trash2 color={colours.delete} />
                       </button>
                     </td>
                   </tr>

--- a/client/src/components/transcribe/TranscriptionsTable.tsx
+++ b/client/src/components/transcribe/TranscriptionsTable.tsx
@@ -6,8 +6,9 @@ import {
   resetTranscriptions,
   transcribe,
 } from 'lib/api/transcribe';
+import colours from 'lib/colours';
 import React from 'react';
-import {Check, Target, XCircle} from 'react-feather';
+import {AlertCircle, Check, Loader, Play, Trash2} from 'react-feather';
 import {transcriptionsAtom} from 'store';
 import Transcription, {TranscriptionStatus} from 'types/Transcription';
 import DownloadTranscriptionFileButton from './DownloadTranscriptionFileButton';
@@ -148,9 +149,9 @@ const DatasetTable: React.FC = () => {
             <tr>
               <th>Model Name</th>
               <th>Audio</th>
-              <th>Status</th>
               <th>Text</th>
               <th>Elan</th>
+              <th>Status</th>
               <th>Transcribe</th>
               <th>Delete</th>
             </tr>
@@ -160,7 +161,6 @@ const DatasetTable: React.FC = () => {
               <tr key={index}>
                 <td>{transcription.modelLocation}</td>
                 <td>{transcription.audioName}.wav</td>
-                <td>{transcription.status}</td>
 
                 <td>
                   <DownloadTranscriptionFileButton
@@ -175,27 +175,22 @@ const DatasetTable: React.FC = () => {
                   />
                 </td>
 
+                <td>{transcription.status}</td>
                 <td>
                   <button
-                    className="px-2 py-1"
                     onClick={() => _transcribe(transcription)}
                     disabled={
                       transcription.status === TranscriptionStatus.Finished
                     }
                   >
-                    {transcription.status === TranscriptionStatus.Finished ? (
-                      <Check />
-                    ) : (
-                      <Target color="blue" />
-                    )}
+                    <TranscriptionStatusIndicator
+                      status={transcription.status}
+                    />
                   </button>
                 </td>
                 <td>
-                  <button
-                    className="px-2 py-1"
-                    onClick={() => removeTranscription(index)}
-                  >
-                    <XCircle color="red" />
+                  <button onClick={() => removeTranscription(index)}>
+                    <Trash2 color={colours.delete} />
                   </button>
                 </td>
               </tr>
@@ -205,6 +200,23 @@ const DatasetTable: React.FC = () => {
       </div>
     </>
   );
+};
+
+type IndicatorProps = {
+  status: TranscriptionStatus;
+};
+
+const TranscriptionStatusIndicator: React.FC<IndicatorProps> = ({status}) => {
+  switch (status) {
+    case TranscriptionStatus.Waiting:
+      return <Play color={colours.start} />;
+    case TranscriptionStatus.Transcribing:
+      return <Loader color={colours.unavailable} className="animate-spin" />;
+    case TranscriptionStatus.Finished:
+      return <Check color={colours.grey} />;
+    case TranscriptionStatus.Error:
+      return <AlertCircle color={colours.error} />;
+  }
 };
 
 export default DatasetTable;

--- a/client/src/lib/colours.ts
+++ b/client/src/lib/colours.ts
@@ -1,0 +1,12 @@
+export const colours = {
+  start: '#58b957',
+  success: '#58b957',
+  info: '#56c0e0',
+  warning: '#f2ae43',
+  error: '#ed5e68',
+  delete: '#ed5e68',
+  grey: '#333',
+  unavailable: '#ccc',
+};
+
+export default colours;

--- a/client/src/styles/globals.css
+++ b/client/src/styles/globals.css
@@ -40,7 +40,7 @@
   }
 
   .table tr td {
-    @apply first:font-normal items-center;
+    @apply first:font-normal;
   }
 
   .button {

--- a/client/src/styles/globals.css
+++ b/client/src/styles/globals.css
@@ -40,7 +40,7 @@
   }
 
   .table tr td {
-    @apply first:font-normal;
+    @apply first:font-normal items-center;
   }
 
   .button {


### PR DESCRIPTION
- Created `lib/colours.ts` to hold global colour content where tailwind can't be used as nicely.
- Used the colours across all tables. 
- Replaced the deletion icon with a trash can to make it more distinct from X 