### PR TITLE
Reuse training status indicator across model table and training viewer

### DIFF
--- a/client/src/components/train/ModelTable.tsx
+++ b/client/src/components/train/ModelTable.tsx
@@ -5,17 +5,10 @@ import colours from 'lib/colours';
 import urls from 'lib/urls';
 import Link from 'next/link';
 import React from 'react';
-import {
-  Trash2,
-  Eye,
-  Download,
-  Check,
-  AlertTriangle,
-  Loader,
-  Play,
-} from 'react-feather';
+import {Trash2, Eye, Download} from 'react-feather';
 import {modelsAtom} from 'store';
 import {TrainingStatus} from 'types/Model';
+import TrainingStatusIndicator from 'components/train/TrainingStatusIndicator';
 
 const ModelTable: React.FC = () => {
   const [models, setModels] = useAtom(modelsAtom);
@@ -101,7 +94,7 @@ const ModelTable: React.FC = () => {
                     model.status === TrainingStatus.Finished
                   }
                 >
-                  <ModelStatusIndicator
+                  <TrainingStatusIndicator
                     status={model.status ?? TrainingStatus.Waiting}
                   />
                 </button>
@@ -138,23 +131,6 @@ const ModelTable: React.FC = () => {
       </table>
     </div>
   );
-};
-
-type Status = {
-  status: TrainingStatus;
-};
-
-const ModelStatusIndicator: React.FC<Status> = ({status}) => {
-  switch (status) {
-    case TrainingStatus.Waiting:
-      return <Play color={colours.start} />;
-    case TrainingStatus.Training:
-      return <Loader color={colours.unavailable} className="animate-spin" />;
-    case TrainingStatus.Finished:
-      return <Check color={colours.grey} />;
-    case TrainingStatus.Error:
-      return <AlertTriangle color={colours.warning} />;
-  }
 };
 
 export default ModelTable;

--- a/client/src/components/train/TrainingStatusIndicator.tsx
+++ b/client/src/components/train/TrainingStatusIndicator.tsx
@@ -1,36 +1,23 @@
 import React from 'react';
-import {Check} from 'react-feather';
 import {TrainingStatus} from 'types/Model';
+import {Play, Loader, Check, AlertTriangle} from 'react-feather';
+import colours from 'lib/colours';
 
-type Props = {
+type Status = {
   status: TrainingStatus;
 };
 
-const TrainingStatusIndicator: React.FC<Props> = ({status}) => {
-  return (
-    <div className="flex items-center space-x-2">
-      {status === TrainingStatus.Training && (
-        <svg
-          aria-hidden="true"
-          className="mr-2 w-8 h-8 text-gray-200 animate-spin dark:text-gray-200 fill-primary"
-          viewBox="0 0 100 101"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z"
-            fill="currentColor"
-          />
-          <path
-            d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z"
-            fill="currentFill"
-          />
-        </svg>
-      )}
-      {status === TrainingStatus.Finished && <Check color="green" />}
-      <p className="font-semibold capitalize">{status}</p>
-    </div>
-  );
+const TrainingStatusIndicator: React.FC<Status> = ({status}) => {
+  switch (status) {
+    case TrainingStatus.Waiting:
+      return <Play color={colours.start} />;
+    case TrainingStatus.Training:
+      return <Loader color={colours.unavailable} className="animate-spin" />;
+    case TrainingStatus.Finished:
+      return <Check color={colours.grey} />;
+    case TrainingStatus.Error:
+      return <AlertTriangle color={colours.warning} />;
+  }
 };
 
 export default TrainingStatusIndicator;

--- a/client/src/components/train/ViewTraining.tsx
+++ b/client/src/components/train/ViewTraining.tsx
@@ -1,8 +1,8 @@
 import {getModelLogs} from 'lib/api/models';
 import fileDownload from 'js-file-download';
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import Model, {TrainingStatus} from 'types/Model';
-import TrainingStatusIndicator from './TrainingStatusIndicator';
+import TrainingStatusIndicator from 'components/train/TrainingStatusIndicator';
 
 type Props = {
   model: Model;
@@ -12,7 +12,6 @@ const LOGS_REFRESH_RATE = 2000;
 
 const ViewTraining: React.FC<Props> = ({model}) => {
   const [logs, setLogs] = useState<string[]>([]);
-  const ref = useRef<HTMLDivElement | null>(null);
 
   // Continuously pull model logs if it's training.
   useEffect(() => {
@@ -22,11 +21,6 @@ const ViewTraining: React.FC<Props> = ({model}) => {
         const blob = await response.blob();
         const logs = await blob.text();
         setLogs(logs.split('\n'));
-        if (ref.current) {
-          ref.current.scrollTo({
-            top: ref.current.scrollHeight + ref.current.offsetHeight,
-          });
-        }
       } else {
         const error = await response.text();
         console.error('Error fetching model logs: ', error);
@@ -57,14 +51,16 @@ const ViewTraining: React.FC<Props> = ({model}) => {
     <div className="mt-8 space-y-4">
       <div className="flex items-center justify-between">
         <p className="subtitle">Training Logs</p>
-        <TrainingStatusIndicator
-          status={model.status ?? TrainingStatus.Training}
-        />
+        <div className="flex space-x-2">
+          <p className="capitalize font-semibold">
+            {model.status ?? TrainingStatus.Training}
+          </p>
+          <TrainingStatusIndicator
+            status={model.status ?? TrainingStatus.Training}
+          />
+        </div>
       </div>
-      <div
-        ref={ref}
-        className="max-h-96 overflow-y-auto bg-slate-800 text-white font-mono text-xs rounded p-3"
-      >
+      <div className="max-h-96 overflow-y-auto bg-slate-800 text-white font-mono text-xs rounded p-3">
         {logs.map((log, index) => (
           <p key={index}>{log}</p>
         ))}


### PR DESCRIPTION
Closes #36 
- Rename/move `ModelStatusIndicator` from the model table to `TrainingStatusIndicator`, which has better support for more `TrainingStatus` states.
- Use the new `TrainingStatusIndicator` for the model table and training viewer.
- Fix an annoying (but good intentioned bug) where new logs would cause the log div to scroll only partially down to the bottom, every 5 seconds when pulling new logs from the server. Now we just give user full control over scrolling through logs. 