### PR TITLE
Make client-side urls consistent.

### DIFF
--- a/client/src/lib/api/datasets.ts
+++ b/client/src/lib/api/datasets.ts
@@ -1,10 +1,10 @@
-import urls, {server} from 'lib/urls';
+import urls, {serverRoute} from 'lib/urls';
 import {CleaningOptions, ElanOptions} from 'types/Dataset';
 
-const baseURL = server + urls.api.datasets;
+const route = urls.api.datasets;
 
 export async function getDatasets(): Promise<Response> {
-  return fetch(baseURL);
+  return fetch(serverRoute(route.index));
 }
 
 export async function createDataset(
@@ -24,7 +24,7 @@ export async function createDataset(
     formData.append('elanOptions', JSON.stringify(elanOptions));
   }
 
-  return fetch(baseURL, {
+  return fetch(serverRoute(route.index), {
     method: 'POST',
     mode: 'cors',
     body: formData,
@@ -32,12 +32,12 @@ export async function createDataset(
 }
 
 export async function deleteDataset(name: string): Promise<Response> {
-  return fetch(`${baseURL}/${name}`, {
+  return fetch(serverRoute(route.dataset(name)), {
     mode: 'cors',
     method: 'DELETE',
   });
 }
 
 export async function downloadDataset(name: string): Promise<Response> {
-  return fetch(`${baseURL}/download/${name}`);
+  return fetch(serverRoute(route.download(name)));
 }

--- a/client/src/lib/api/datasets.ts
+++ b/client/src/lib/api/datasets.ts
@@ -1,10 +1,10 @@
 import urls, {server} from 'lib/urls';
 import {CleaningOptions, ElanOptions} from 'types/Dataset';
 
-const url = server + urls.api.datasets;
+const baseURL = server + urls.api.datasets;
 
 export async function getDatasets(): Promise<Response> {
-  return fetch(url);
+  return fetch(baseURL);
 }
 
 export async function createDataset(
@@ -24,7 +24,7 @@ export async function createDataset(
     formData.append('elanOptions', JSON.stringify(elanOptions));
   }
 
-  return fetch(url, {
+  return fetch(baseURL, {
     method: 'POST',
     mode: 'cors',
     body: formData,
@@ -32,12 +32,12 @@ export async function createDataset(
 }
 
 export async function deleteDataset(name: string): Promise<Response> {
-  return fetch(`${url}${name}`, {
+  return fetch(`${baseURL}/${name}`, {
     mode: 'cors',
     method: 'DELETE',
   });
 }
 
 export async function downloadDataset(name: string): Promise<Response> {
-  return fetch(`${url}download/${name}`);
+  return fetch(`${baseURL}/download/${name}`);
 }

--- a/client/src/lib/api/models.ts
+++ b/client/src/lib/api/models.ts
@@ -1,14 +1,14 @@
-import urls, {server} from 'lib/urls';
+import urls, {serverRoute} from 'lib/urls';
 import Model from 'types/Model';
 
-const baseURL = server + urls.api.models;
+const route = urls.api.models;
 
 export async function getModels(): Promise<Response> {
-  return fetch(baseURL);
+  return fetch(serverRoute(route.index));
 }
 
 export async function createModel(model: Model): Promise<Response> {
-  return fetch(baseURL, {
+  return fetch(serverRoute(route.index), {
     method: 'POST',
     mode: 'cors',
     body: JSON.stringify(model),
@@ -19,29 +19,29 @@ export async function createModel(model: Model): Promise<Response> {
 }
 
 export async function deleteModel(modelName: string): Promise<Response> {
-  return fetch(`${baseURL}/${modelName}`, {
+  return fetch(serverRoute(route.model(modelName)), {
     mode: 'cors',
     method: 'DELETE',
   });
 }
 
 export async function trainModel(modelName: string): Promise<Response> {
-  return fetch(`${baseURL}/train/${modelName}`);
+  return fetch(serverRoute(route.train(modelName)));
 }
 
 export async function getModelLogs(modelName: string): Promise<Response> {
-  return fetch(`${baseURL}/logs/${modelName}`);
+  return fetch(serverRoute(route.logs(modelName)));
 }
 
 export async function getModelStatus(modelName: string): Promise<Response> {
-  return fetch(`${baseURL}/status/${modelName}`);
+  return fetch(serverRoute(route.status(modelName)));
 }
 
 export async function uploadModel(modelZip: File): Promise<Response> {
   const formData = new FormData();
   formData.append('file', modelZip);
 
-  return fetch(`${baseURL}/upload`, {
+  return fetch(serverRoute(route.upload), {
     method: 'POST',
     mode: 'cors',
     body: formData,
@@ -49,5 +49,5 @@ export async function uploadModel(modelZip: File): Promise<Response> {
 }
 
 export async function downloadModel(modelName: string): Promise<Response> {
-  return fetch(`${baseURL}/download/${modelName}`);
+  return fetch(serverRoute(route.download(modelName)));
 }

--- a/client/src/lib/api/models.ts
+++ b/client/src/lib/api/models.ts
@@ -1,14 +1,14 @@
 import urls, {server} from 'lib/urls';
 import Model from 'types/Model';
 
-const url = server + urls.api.models;
+const baseURL = server + urls.api.models;
 
 export async function getModels(): Promise<Response> {
-  return fetch(url);
+  return fetch(baseURL);
 }
 
 export async function createModel(model: Model): Promise<Response> {
-  return fetch(url, {
+  return fetch(baseURL, {
     method: 'POST',
     mode: 'cors',
     body: JSON.stringify(model),
@@ -19,29 +19,29 @@ export async function createModel(model: Model): Promise<Response> {
 }
 
 export async function deleteModel(modelName: string): Promise<Response> {
-  return fetch(`${url}${modelName}`, {
+  return fetch(`${baseURL}/${modelName}`, {
     mode: 'cors',
     method: 'DELETE',
   });
 }
 
 export async function trainModel(modelName: string): Promise<Response> {
-  return fetch(`${url}train/${modelName}`);
+  return fetch(`${baseURL}/train/${modelName}`);
 }
 
 export async function getModelLogs(modelName: string): Promise<Response> {
-  return fetch(`${url}logs/${modelName}`);
+  return fetch(`${baseURL}/logs/${modelName}`);
 }
 
 export async function getModelStatus(modelName: string): Promise<Response> {
-  return fetch(`${url}status/${modelName}`);
+  return fetch(`${baseURL}/status/${modelName}`);
 }
 
 export async function uploadModel(modelZip: File): Promise<Response> {
   const formData = new FormData();
   formData.append('file', modelZip);
 
-  return fetch(`${url}upload`, {
+  return fetch(`${baseURL}/upload`, {
     method: 'POST',
     mode: 'cors',
     body: formData,
@@ -49,5 +49,5 @@ export async function uploadModel(modelZip: File): Promise<Response> {
 }
 
 export async function downloadModel(modelName: string): Promise<Response> {
-  return fetch(`${url}download/${modelName}`);
+  return fetch(`${baseURL}/download/${modelName}`);
 }

--- a/client/src/lib/api/transcribe.ts
+++ b/client/src/lib/api/transcribe.ts
@@ -1,13 +1,13 @@
-import urls, {server} from 'lib/urls';
+import urls, {serverRoute} from 'lib/urls';
 
-const baseURL = server + urls.api.transcriptions;
+const route = urls.api.transcriptions;
 
 export async function getTranscriptions(): Promise<Response> {
-  return fetch(baseURL);
+  return fetch(serverRoute(route.index));
 }
 
 export async function resetTranscriptions(): Promise<Response> {
-  return fetch(baseURL + '/reset');
+  return fetch(serverRoute(route.reset));
 }
 
 export async function deleteTranscription(
@@ -18,7 +18,8 @@ export async function deleteTranscription(
     modelLocation,
     audioName,
   });
-  return fetch(`${baseURL}?${params}`, {
+  const url = `${serverRoute(route.index)}?${params}`;
+  return fetch(url, {
     method: 'DELETE',
     mode: 'cors',
   });
@@ -35,7 +36,7 @@ export async function createTranscriptionJobs(
   });
   formData.append('modelLocation', modelLocation);
 
-  return fetch(baseURL, {
+  return fetch(serverRoute(route.index), {
     method: 'POST',
     mode: 'cors',
     body: formData,
@@ -50,7 +51,7 @@ export async function transcribe(
     modelLocation,
     audioName,
   });
-  return fetch(`${baseURL}/transcribe?${params}`);
+  return fetch(`${serverRoute(route.transcribe)}?${params}`);
 }
 
 export async function getTranscriptionStatus(
@@ -61,7 +62,7 @@ export async function getTranscriptionStatus(
     modelLocation,
     audioName,
   });
-  return fetch(`${baseURL}/status?${params}`);
+  return fetch(`${serverRoute(route.status)}?${params}`);
 }
 
 export async function getText(
@@ -72,7 +73,7 @@ export async function getText(
     modelLocation,
     audioName,
   });
-  return fetch(`${baseURL}/text?${params}`);
+  return fetch(`${serverRoute(route.text)}?${params}`);
 }
 
 export async function getElan(
@@ -83,9 +84,9 @@ export async function getElan(
     modelLocation,
     audioName,
   });
-  return fetch(`${baseURL}/elan?${params}`);
+  return fetch(`${serverRoute(route.elan)}?${params}`);
 }
 
 export async function downloadFiles(): Promise<Response> {
-  return fetch(`${baseURL}/download`);
+  return fetch(serverRoute(route.download));
 }

--- a/client/src/lib/api/transcribe.ts
+++ b/client/src/lib/api/transcribe.ts
@@ -1,13 +1,13 @@
 import urls, {server} from 'lib/urls';
 
-const url = server + urls.api.transcriptions;
-
-export async function resetTranscriptions(): Promise<Response> {
-  return fetch(url + 'reset');
-}
+const baseURL = server + urls.api.transcriptions;
 
 export async function getTranscriptions(): Promise<Response> {
-  return fetch(url);
+  return fetch(baseURL);
+}
+
+export async function resetTranscriptions(): Promise<Response> {
+  return fetch(baseURL + '/reset');
 }
 
 export async function deleteTranscription(
@@ -18,7 +18,7 @@ export async function deleteTranscription(
     modelLocation,
     audioName,
   });
-  return fetch(`${url}?${params}`, {
+  return fetch(`${baseURL}?${params}`, {
     method: 'DELETE',
     mode: 'cors',
   });
@@ -35,7 +35,7 @@ export async function createTranscriptionJobs(
   });
   formData.append('modelLocation', modelLocation);
 
-  return fetch(url, {
+  return fetch(baseURL, {
     method: 'POST',
     mode: 'cors',
     body: formData,
@@ -50,7 +50,7 @@ export async function transcribe(
     modelLocation,
     audioName,
   });
-  return fetch(`${url}transcribe?${params}`);
+  return fetch(`${baseURL}/transcribe?${params}`);
 }
 
 export async function getTranscriptionStatus(
@@ -61,7 +61,7 @@ export async function getTranscriptionStatus(
     modelLocation,
     audioName,
   });
-  return fetch(`${url}status?${params}`);
+  return fetch(`${baseURL}/status?${params}`);
 }
 
 export async function getText(
@@ -72,7 +72,7 @@ export async function getText(
     modelLocation,
     audioName,
   });
-  return fetch(`${url}text?${params}`);
+  return fetch(`${baseURL}/text?${params}`);
 }
 
 export async function getElan(
@@ -83,9 +83,9 @@ export async function getElan(
     modelLocation,
     audioName,
   });
-  return fetch(`${url}elan?${params}`);
+  return fetch(`${baseURL}/elan?${params}`);
 }
 
 export async function downloadFiles(): Promise<Response> {
-  return fetch(`${url}download`);
+  return fetch(`${baseURL}/download`);
 }

--- a/client/src/lib/urls.ts
+++ b/client/src/lib/urls.ts
@@ -25,9 +25,9 @@ export const urls = {
     view: '/transcriptions/view',
   },
   api: {
-    datasets: '/api/datasets/',
-    models: '/api/models/',
-    transcriptions: '/api/transcriptions/',
+    datasets: '/api/datasets',
+    models: '/api/models',
+    transcriptions: '/api/transcriptions',
   },
 };
 

--- a/client/src/lib/urls.ts
+++ b/client/src/lib/urls.ts
@@ -6,6 +6,8 @@ export const server = `${host}:${serverPort}`;
 export const tensorboardPort = process.env.TENSORBOARD_PORT ?? '6006';
 export const tensorboard = `${host}:${tensorboardPort}`;
 
+export const serverRoute = (route: string) => server + route;
+
 export const urls = {
   train: {
     index: '/train',
@@ -25,10 +27,31 @@ export const urls = {
     view: '/transcriptions/view',
   },
   api: {
-    datasets: '/api/datasets',
-    models: '/api/models',
-    transcriptions: '/api/transcriptions',
+    datasets: {
+      index: '/api/datasets/', // Trailing slashes necessary for flask
+      dataset: (datasetName: string) => `/api/datasets/${datasetName}`,
+      download: (datasetName: string) =>
+        `/api/datasets/download/${datasetName}`,
+    },
+    models: {
+      index: '/api/models/',
+      model: (modelName: string) => `/api/models/${modelName}`,
+      train: (modelName: string) => `/api/models/train/${modelName}`,
+      logs: (modelName: string) => `/api/models/logs/${modelName}`,
+      status: (modelName: string) => `/api/models/status/${modelName}`,
+      upload: '/api/models/upload',
+      download: (modelName: string) => `/api/models/download/${modelName}`,
+    },
+    transcriptions: {
+      index: '/api/transcriptions/',
+      reset: '/api/transcriptions/reset',
+      transcribe: '/api/transcriptions/transcribe',
+      status: '/api/transcriptions/status',
+      text: '/api/transcriptions/text',
+      elan: '/api/transcriptions/elan',
+      download: '/api/transcriptions/download',
+    },
   },
-};
+} as const;
 
 export default urls;


### PR DESCRIPTION
Closes #49 

This was something that was brought up in the pair programming session, but some of the client urls ended in a backslash, and some didn't. This commit aims to bring more consistency to the url handling on the client side in general.

One concern I have is that the function called `serverRoute(someRoute)` might be better used as `server + someRoute`? Up to you @savitadatta. 

Tested the majority of page routes (manually) after writing the changes.