### PR TITLE
UI Overhaul (datasets)

### DIFF
--- a/client/components.json
+++ b/client/components.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "default",
+  "rsc": false,
+  "tsx": true,
+  "tailwind": {
+    "config": "tailwind.config.js",
+    "css": "src/styles/globals.css",
+    "baseColor": "slate",
+    "cssVariables": false
+  },
+  "aliases": {
+    "components": "components",
+    "utils": "lib/utils"
+  }
+}

--- a/client/package.json
+++ b/client/package.json
@@ -15,14 +15,20 @@
     "posttest": "yarn run lint"
   },
   "dependencies": {
+    "@radix-ui/react-slot": "^1.0.2",
+    "class-variance-authority": "^0.6.1",
+    "clsx": "^1.2.1",
     "jotai": "^1.8.6",
     "js-file-download": "^0.4.12",
+    "lucide-react": "^0.259.0",
     "next": "12.3.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-dropzone": "^14.2.3",
     "react-feather": "^2.0.10",
-    "sharp": "^0.31.2"
+    "sharp": "^0.31.2",
+    "tailwind-merge": "^1.13.2",
+    "tailwindcss-animate": "^1.0.6"
   },
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.3",

--- a/client/package.json
+++ b/client/package.json
@@ -15,6 +15,8 @@
     "posttest": "yarn run lint"
   },
   "dependencies": {
+    "@radix-ui/react-label": "^2.0.2",
+    "@radix-ui/react-select": "^1.2.2",
     "@radix-ui/react-slot": "^1.0.2",
     "class-variance-authority": "^0.6.1",
     "clsx": "^1.2.1",

--- a/client/src/components/DataTable.tsx
+++ b/client/src/components/DataTable.tsx
@@ -1,0 +1,190 @@
+import React, {useEffect, useState} from 'react';
+import {ArrowLeft, ArrowRight, MoreVertical} from 'react-feather';
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from 'components/ui/table';
+import {Button} from './ui/button';
+
+/**
+ * An action section to be embedded at the end of the table in the hidden menu.
+ */
+export type Action<T> = {
+  name: string;
+  icon(item: T, index: number): React.ReactNode;
+  action?(item: T, index: number): void;
+  tooltip?: string;
+};
+
+/**
+ * Table colums which represent a section of the data.
+ */
+export type Section<T> = {
+  name: string;
+  tooltip?: string;
+  containerOptions?: React.HTMLAttributes<HTMLTableCellElement>;
+  display(item: T, index: number): React.ReactNode;
+};
+
+type TableProps<T> = {
+  data: T[];
+  sections: Section<T>[];
+  actions?: Action<T>[];
+  caption?: string;
+};
+
+/**
+ * A component to display some generic tabular data.
+ *
+ * Each row is made up of <sections[0] ... sections.[n-1]> , <?moreActions>
+ * Where more actions is a menu which only appears if actions.length > 0
+ */
+const DataTable = <T,>({
+  data,
+  sections,
+  actions = [],
+  caption,
+}: TableProps<T>) => {
+  const [popupIndex, setPopupIndex] = useState<number>(0);
+  const [open, setOpen] = useState(false);
+  const [page, setPage] = useState(0);
+  const [limit, setLimit] = useState(10);
+
+  const togglePopup = (index: number) => () => {
+    setPopupIndex(index);
+    setOpen(!open);
+  };
+
+  const totalPages = Math.ceil(data.length / limit);
+  const startIndex = page * limit;
+  const endIndex = (page + 1) * limit;
+  const pageData = data.slice(startIndex, endIndex);
+
+  const changePage = (delta: number) => {
+    setPage(page => Math.min(Math.max(page + delta, 0), totalPages - 1));
+  };
+
+  useEffect(() => {
+    setPage(0);
+  }, [data]);
+
+  const Paginator = () => {
+    return (
+      <div className="my-4 flex justify-between items-center">
+        <p className="text-gray-600 text-xs">
+          Showing <span className="font-semibold">{startIndex + 1}</span> to{' '}
+          <span className="font-semibold">
+            {Math.min(endIndex, data.length)}
+          </span>{' '}
+          of <span className="font-semibold">{data.length}</span> results.
+        </p>
+        <div className="flex items-center gap-2 text-xs">
+          <Button
+            variant="secondary"
+            size="icon"
+            onClick={() => changePage(-1)}
+            disabled={page === 0}
+          >
+            <ArrowLeft size={20} />
+          </Button>
+          <p>Page {page + 1}</p>
+          <Button
+            variant="secondary"
+            size="icon"
+            onClick={() => changePage(+1)}
+            disabled={page === totalPages - 1}
+          >
+            <ArrowRight size={20} />
+          </Button>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div>
+      <div className="border rounded w-full">
+        <Table>
+          {caption && <TableCaption>{caption}</TableCaption>}
+          <TableHeader>
+            <TableRow>
+              {sections.map(section => (
+                <TableHead key={section.name}>{section.name}</TableHead>
+              ))}
+              {actions.length > 0 && <TableHead>Actions</TableHead>}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {pageData.map((item, index) => (
+              <TableRow key={index}>
+                {sections.map((section, sectionIndex) => (
+                  <TableCell
+                    key={sectionIndex}
+                    {...(section.containerOptions ?? {})}
+                  >
+                    {section.display(item, index)}
+                  </TableCell>
+                ))}
+                {actions.length > 0 && (
+                  <TableCell className="relative text-center w-0">
+                    <Button size="icon" onClick={togglePopup(index)}>
+                      <MoreVertical />
+                    </Button>
+
+                    <ActionPopup
+                      item={item}
+                      actions={actions}
+                      isOpen={index === popupIndex && open}
+                      close={() => setOpen(false)}
+                    />
+                  </TableCell>
+                )}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      <Paginator />
+    </div>
+  );
+};
+
+type ActionPopupProps<T> = {
+  item: T;
+  isOpen: boolean;
+  close: () => void;
+  actions: Action<T>[];
+};
+
+const ActionPopup = <T,>({
+  item,
+  isOpen,
+  close,
+  actions,
+}: ActionPopupProps<T>) => {
+  if (!isOpen) return null;
+  return (
+    <div
+      className="z-10 absolute top-1 flex flex-col bg-white border"
+      onMouseLeave={close}
+    >
+      {actions.map((action, index) => (
+        <div
+          className="p-3 flex gap-2 cursor-pointer hover:bg-gray-50"
+          key={index}
+          onClick={() => action.action?.(item, index)}
+        >
+          {action.icon(item, index)}
+          <span>{action.name}</span>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default DataTable;

--- a/client/src/components/datasets/ChooseCleaningOptions.tsx
+++ b/client/src/components/datasets/ChooseCleaningOptions.tsx
@@ -1,4 +1,8 @@
+import {Badge} from 'components/ui/badge';
 import {Button} from 'components/ui/button';
+import {Card, CardContent, CardHeader, CardTitle} from 'components/ui/card';
+import {Input} from 'components/ui/input';
+import {Label} from 'components/ui/label';
 import {useAtom} from 'jotai';
 import React, {useState} from 'react';
 import {X} from 'react-feather';
@@ -36,58 +40,62 @@ const ChooseCleaningOptions: React.FC = () => {
   };
 
   return (
-    <div className="section">
-      <h2 className="subtitle">Choose Cleaning Options</h2>
-
-      <div className="mt-4 space-y-2">
-        <div className="space-x-2">
-          <label htmlFor="puncRemove">Punctuation to Remove:</label>
-          <input
-            id="puncRemove"
-            className="rounded"
-            type="text"
-            value={cleaningOptions.punctuationToRemove}
-            onChange={changePunctuation('punctuationToRemove')}
-          />
-        </div>
-      </div>
-      <div className="space-x-2 mt-2">
-        <label htmlFor="puncExplode">Punctuation to Explode:</label>
-        <input
-          id="puncExplode"
-          className="rounded"
-          type="text"
-          value={cleaningOptions.punctuationToExplode}
-          onChange={changePunctuation('punctuationToExplode')}
-        />
-      </div>
-
-      <p className="mt-4 font-semibold">Words to Remove</p>
-      <div className="space-x-2 mt-2">
-        <label htmlFor="word">Add Word: </label>
-        <input
-          id="word"
-          className="rounded"
-          type="text"
-          value={nextWord}
-          onChange={e => setNextWord(e.target.value)}
-        />
-        <Button onClick={addWord}>Add</Button>
-      </div>
-      <div className="mt-4 flex gap-1">
-        {cleaningOptions.wordsToRemove.map(word => (
-          <div
-            key={word}
-            className="shadow bg-purple-50 border border-purple-200 p-1 rounded flex items-center space-x-2"
-          >
-            <p className="text-purple-400">{word}</p>
-            <button onClick={() => removeWord(word)}>
-              <X />
-            </button>
+    <Card>
+      <CardHeader>
+        <CardTitle className="subtitle">Choose Cleaning Options</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-2">
+          <div>
+            <Label htmlFor="puncRemove">Punctuation to Remove</Label>
+            <Input
+              id="puncRemove"
+              type="text"
+              value={cleaningOptions.punctuationToRemove}
+              onChange={changePunctuation('punctuationToRemove')}
+            />
           </div>
-        ))}
-      </div>
-    </div>
+          <div>
+            <Label htmlFor="puncExplode">Punctuation to Explode</Label>
+            <Input
+              id="puncExplode"
+              type="text"
+              value={cleaningOptions.punctuationToExplode}
+              onChange={changePunctuation('punctuationToExplode')}
+            />
+          </div>
+
+          <div>
+            <Label htmlFor="word" className="mt-4">
+              Words to Remove
+            </Label>
+            <div className="w-full flex gap-2 items-center">
+              <Input
+                id="word"
+                type="text"
+                value={nextWord}
+                onChange={e => setNextWord(e.target.value)}
+              />
+              <Button onClick={addWord} className="w-32">
+                Add Word
+              </Button>
+            </div>
+          </div>
+        </div>
+        <div className="mt-4 flex gap-1">
+          {cleaningOptions.wordsToRemove.map(word => (
+            <Badge
+              variant="secondary"
+              key={word}
+              onClick={() => removeWord(word)}
+              className="cursor-pointer"
+            >
+              {word}
+            </Badge>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
   );
 };
 

--- a/client/src/components/datasets/ChooseCleaningOptions.tsx
+++ b/client/src/components/datasets/ChooseCleaningOptions.tsx
@@ -1,3 +1,4 @@
+import {Button} from 'components/ui/button';
 import {useAtom} from 'jotai';
 import React, {useState} from 'react';
 import {X} from 'react-feather';
@@ -71,9 +72,7 @@ const ChooseCleaningOptions: React.FC = () => {
           value={nextWord}
           onChange={e => setNextWord(e.target.value)}
         />
-        <button className="button" onClick={addWord}>
-          Add
-        </button>
+        <Button onClick={addWord}>Add</Button>
       </div>
       <div className="mt-4 flex gap-1">
         {cleaningOptions.wordsToRemove.map(word => (

--- a/client/src/components/datasets/ChooseDatasetName.tsx
+++ b/client/src/components/datasets/ChooseDatasetName.tsx
@@ -1,3 +1,6 @@
+import {Card, CardContent, CardHeader, CardTitle} from 'components/ui/card';
+import {Input} from 'components/ui/input';
+import {Label} from 'components/ui/label';
 import {useAtom} from 'jotai';
 import React from 'react';
 import {datasetNameAtom} from 'store';
@@ -6,18 +9,19 @@ export default function ChooseDatasetName() {
   const [name, setName] = useAtom(datasetNameAtom);
 
   return (
-    <div className="section">
-      <h2 className="subtitle">Choose Dataset Name</h2>
-
-      <div className="mt-4 space-x-2">
-        <label>Name:</label>
-        <input
+    <Card>
+      <CardHeader>
+        <CardTitle>Choose Dataset Name</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Label>Name</Label>
+        <Input
           type="text"
           value={name}
           onChange={e => setName(e.target.value)}
           className="rounded"
         />
-      </div>
-    </div>
+      </CardContent>
+    </Card>
   );
 }

--- a/client/src/components/datasets/ChooseElanOptions.tsx
+++ b/client/src/components/datasets/ChooseElanOptions.tsx
@@ -1,3 +1,15 @@
+import {Card, CardContent, CardHeader, CardTitle} from 'components/ui/card';
+import {Input} from 'components/ui/input';
+import {Label} from 'components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from 'components/ui/select';
 import {useAtom} from 'jotai';
 import React from 'react';
 import {elanOptionsAtom, filesAtom} from 'store';
@@ -19,40 +31,46 @@ const ChooseElanOptions: React.FC = () => {
   }
 
   return (
-    <div className="section">
-      <h2 className="subtitle">Choose Elan Options</h2>
+    <Card>
+      <CardHeader>
+        <CardTitle>Choose Elan Options</CardTitle>
+      </CardHeader>
 
-      <div className="mt-4 space-y-2">
-        <div className="space-x-2">
-          <label htmlFor="selectionMechanism">Selection Mechanism:</label>
-          <select
-            className="rounded"
-            name="selectionMechanism"
-            id="selectionMechanism"
+      <CardContent className="space-y-2">
+        <div>
+          <Label htmlFor="selectionMechanism">Selection Mechanism</Label>
+          <Select
             value={elanOptions.selectionMechanism}
-            onChange={e => {
-              const mechanism = e.target.value as ElanTierSelector;
+            onValueChange={value => {
+              const mechanism = value as ElanTierSelector;
               setElanOptions({
                 selectionMechanism: mechanism,
                 selectionValue: DEFAULT_VALUES.get(mechanism) ?? 'Phrase',
               });
             }}
           >
-            {[
-              ElanTierSelector.Name,
-              ElanTierSelector.Order,
-              ElanTierSelector.Type,
-            ].map(selector => (
-              <option key={selector} value={selector}>
-                {selector}
-              </option>
-            ))}
-          </select>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                <SelectLabel>Selection Mechanisms</SelectLabel>
+                {[
+                  ElanTierSelector.Name,
+                  ElanTierSelector.Order,
+                  ElanTierSelector.Type,
+                ].map(selector => (
+                  <SelectItem key={selector} value={selector}>
+                    {selector}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+            </SelectContent>
+          </Select>
         </div>
-        <div className="space-x-2">
-          <label htmlFor="selectionValue">Selection Value*:</label>
-          <input
-            className="rounded"
+        <div>
+          <Label htmlFor="selectionValue">Selection Value</Label>
+          <Input
             type={
               elanOptions.selectionMechanism === ElanTierSelector.Order
                 ? 'number'
@@ -66,8 +84,8 @@ const ChooseElanOptions: React.FC = () => {
             }
           />
         </div>
-      </div>
-    </div>
+      </CardContent>
+    </Card>
   );
 };
 

--- a/client/src/components/datasets/DatasetFiles.tsx
+++ b/client/src/components/datasets/DatasetFiles.tsx
@@ -6,6 +6,13 @@ import {Trash2, Check, X, AlertTriangle} from 'react-feather';
 import {FileType, hasMatch, parseFileType} from 'lib/dataset';
 import colours from 'lib/colours';
 import {Card, CardContent, CardHeader, CardTitle} from 'components/ui/card';
+import DataTable, {Section} from 'components/DataTable';
+import {Button} from 'components/ui/button';
+
+type DatasetFile = {
+  file: File;
+  type: string;
+};
 
 const DatasetFiles: React.FC = () => {
   const [files, setFiles] = useAtom(filesAtom);
@@ -22,75 +29,69 @@ const DatasetFiles: React.FC = () => {
   const deleteFile = (name: string) =>
     setFiles(files.filter(file => file.name !== name));
 
-  const fileRows = (selectedFiles: File[], type: string) =>
-    selectedFiles.map((file, index) => (
-      <tr key={index} className="text-gray-600 text-sm">
-        <td>{file.name}</td>
-        <td>{type}</td>
-        <td>
-          {hasMatch(
-            file.name,
-            files.map(file => file.name)
-          ) ? (
-            <Check color={colours.success} />
-          ) : (
-            <X color={colours.warning} />
-          )}
-        </td>
-        <td>
-          <button className="px-2 py-1" onClick={() => deleteFile(file.name)}>
-            <Trash2 color={colours.delete} />
-          </button>
-        </td>
-      </tr>
-    ));
+  const data = [
+    ...transcriptionFiles.map(file => ({file, type: 'Transcription'})),
+    ...audioFiles.map(file => ({file, type: 'Audio'})),
+  ];
+
+  const sections: Section<DatasetFile>[] = [
+    {name: 'File name', display: item => item.file.name},
+    {name: 'Type', display: item => item.type},
+    {
+      name: 'Has match',
+      display: item =>
+        hasMatch(
+          item.file.name,
+          files.map(file => file.name)
+        ) ? (
+          <Check color={colours.success} />
+        ) : (
+          <X color={colours.warning} />
+        ),
+    },
+    {
+      name: 'Delete',
+      display: item => (
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={() => deleteFile(item.file.name)}
+        >
+          <Trash2 color={colours.delete} />
+        </Button>
+      ),
+    },
+  ];
 
   return (
     <Card>
       <CardHeader>
         <CardTitle>Upload Dataset Files</CardTitle>
       </CardHeader>
-      <CardContent>
+      <CardContent className="space-y-4">
         <FileDropper callback={_files => setFiles([...files, ..._files])} />
-        {files.length > 0 && (
-          <>
-            <p className="mt-8 text-lg">Files to Upload:</p>
-            <table className="w-full mt-2 table">
-              <thead className="text-sm">
-                <tr>
-                  <th className="text-left">File name</th>
-                  <th className="text-left">Type</th>
-                  <th className="text-left">Has match</th>
-                  <th className="text-left">Delete</th>
-                </tr>
-              </thead>
-              <tbody>
-                {fileRows(transcriptionFiles, 'Transcription')}
-                {fileRows(audioFiles, 'Audio')}
-              </tbody>
-            </table>
-          </>
-        )}
+        {files.length > 0 && <DataTable data={data} sections={sections} />}
 
         {unsupportedFiles.length > 0 && (
-          <div className="mt-4 p-4 border border-orange-300 rounded">
+          <div className="mt-4 p-4 border border-orange-300 rounded space-y-4">
             <div className="flex space-x-2">
               <AlertTriangle color={colours.warning}></AlertTriangle>
-              <p>Unsupported Files:</p>
+              <p className="text-amber-500 font-bold">Unsupported Files</p>
             </div>
             <div className="mt-2 flex text-sm">
               {unsupportedFiles.map(file => (
-                <p key={file.name}>{file.name}</p>
+                <code key={file.name}>{file.name}</code>
               ))}
             </div>
-            <button
-              className="mt-4 button text-sm"
+            <Button
+              className="mt-2"
+              variant="destructive"
               onClick={() =>
                 unsupportedFiles.forEach(file => deleteFile(file.name))
               }
             >
               Delete all Unsupported
-            </button>
+            </Button>
           </div>
         )}
       </CardContent>

--- a/client/src/components/datasets/DatasetFiles.tsx
+++ b/client/src/components/datasets/DatasetFiles.tsx
@@ -5,6 +5,7 @@ import {filesAtom} from 'store';
 import {Trash2, Check, X, AlertTriangle} from 'react-feather';
 import {FileType, hasMatch, parseFileType} from 'lib/dataset';
 import colours from 'lib/colours';
+import {Card, CardContent, CardHeader, CardTitle} from 'components/ui/card';
 
 const DatasetFiles: React.FC = () => {
   const [files, setFiles] = useAtom(filesAtom);
@@ -45,51 +46,55 @@ const DatasetFiles: React.FC = () => {
     ));
 
   return (
-    <div className="p-4 border rounded">
-      <h2 className="subtitle mb-4">Upload Dataset Files</h2>
-      <FileDropper callback={_files => setFiles([...files, ..._files])} />
-      {files.length > 0 && (
-        <>
-          <p className="mt-8 text-lg">Files to Upload:</p>
-          <table className="w-full mt-2 table">
-            <thead className="text-sm">
-              <tr>
-                <th className="text-left">File name</th>
-                <th className="text-left">Type</th>
-                <th className="text-left">Has match</th>
-                <th className="text-left">Delete</th>
-              </tr>
-            </thead>
-            <tbody>
-              {fileRows(transcriptionFiles, 'Transcription')}
-              {fileRows(audioFiles, 'Audio')}
-            </tbody>
-          </table>
-        </>
-      )}
+    <Card>
+      <CardHeader>
+        <CardTitle>Upload Dataset Files</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <FileDropper callback={_files => setFiles([...files, ..._files])} />
+        {files.length > 0 && (
+          <>
+            <p className="mt-8 text-lg">Files to Upload:</p>
+            <table className="w-full mt-2 table">
+              <thead className="text-sm">
+                <tr>
+                  <th className="text-left">File name</th>
+                  <th className="text-left">Type</th>
+                  <th className="text-left">Has match</th>
+                  <th className="text-left">Delete</th>
+                </tr>
+              </thead>
+              <tbody>
+                {fileRows(transcriptionFiles, 'Transcription')}
+                {fileRows(audioFiles, 'Audio')}
+              </tbody>
+            </table>
+          </>
+        )}
 
-      {unsupportedFiles.length > 0 && (
-        <div className="mt-4 p-4 border border-orange-300 rounded">
-          <div className="flex space-x-2">
-            <AlertTriangle color={colours.warning}></AlertTriangle>
-            <p>Unsupported Files:</p>
+        {unsupportedFiles.length > 0 && (
+          <div className="mt-4 p-4 border border-orange-300 rounded">
+            <div className="flex space-x-2">
+              <AlertTriangle color={colours.warning}></AlertTriangle>
+              <p>Unsupported Files:</p>
+            </div>
+            <div className="mt-2 flex text-sm">
+              {unsupportedFiles.map(file => (
+                <p key={file.name}>{file.name}</p>
+              ))}
+            </div>
+            <button
+              className="mt-4 button text-sm"
+              onClick={() =>
+                unsupportedFiles.forEach(file => deleteFile(file.name))
+              }
+            >
+              Delete all Unsupported
+            </button>
           </div>
-          <div className="mt-2 flex text-sm">
-            {unsupportedFiles.map(file => (
-              <p key={file.name}>{file.name}</p>
-            ))}
-          </div>
-          <button
-            className="mt-4 button text-sm"
-            onClick={() =>
-              unsupportedFiles.forEach(file => deleteFile(file.name))
-            }
-          >
-            Delete all Unsupported
-          </button>
-        </div>
-      )}
-    </div>
+        )}
+      </CardContent>
+    </Card>
   );
 };
 

--- a/client/src/components/train/ChooseDataset.tsx
+++ b/client/src/components/train/ChooseDataset.tsx
@@ -1,3 +1,4 @@
+import {Button} from 'components/ui/button';
 import {useAtom} from 'jotai';
 import urls from 'lib/urls';
 import Link from 'next/link';
@@ -51,12 +52,15 @@ export default function ChooseDataset() {
       </div>
 
       <div className="flex items-center justify-between mt-8">
-        <button className="button" onClick={() => setStage(NewModelStage.Name)}>
+        <Button
+          variant="secondary"
+          onClick={() => setStage(NewModelStage.Name)}
+        >
           Back
-        </button>
-        <button className="button" disabled={!hasDataset} onClick={save}>
+        </Button>
+        <Button disabled={!hasDataset} onClick={save}>
           Next
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/client/src/components/train/ChooseModelName.tsx
+++ b/client/src/components/train/ChooseModelName.tsx
@@ -1,3 +1,4 @@
+import {Button} from 'components/ui/button';
 import {useAtom} from 'jotai';
 import React, {useState} from 'react';
 import {newModelAtom, newModelStageAtom} from 'store';
@@ -29,12 +30,12 @@ export default function ChooseModelName() {
       </div>
 
       <div className="flex items-center justify-between mt-8">
-        <button className="button" disabled>
+        <Button variant="outline" disabled>
           Back
-        </button>
-        <button className="button" disabled={!hasName} onClick={save}>
+        </Button>
+        <Button className="button" disabled={!hasName} onClick={save}>
           Next
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/client/src/components/train/ChooseModelOptions.tsx
+++ b/client/src/components/train/ChooseModelOptions.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import {newModelAtom, newModelStageAtom} from 'store';
 import {useResetAtom} from 'jotai/utils';
 import {BASE_MODEL, NewModelStage} from 'types/Model';
+import {Button} from 'components/ui/button';
 
 export default function ChooseModelOptions() {
   const router = useRouter();
@@ -64,17 +65,17 @@ export default function ChooseModelOptions() {
       </div>
 
       <div className="flex items-center justify-between mt-8">
-        <button
-          className="button"
+        <Button
+          variant="secondary"
           onClick={() => {
             setStage(NewModelStage.TrainingOptions);
           }}
         >
           Back
-        </button>
-        <button className="button" disabled={!isValid()} onClick={save}>
+        </Button>
+        <Button disabled={!isValid()} onClick={save}>
           Save
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/client/src/components/train/ChooseTrainingOptions.tsx
+++ b/client/src/components/train/ChooseTrainingOptions.tsx
@@ -1,3 +1,4 @@
+import {Button} from 'components/ui/button';
 import {useAtom} from 'jotai';
 import React from 'react';
 import {newModelAtom, newModelStageAtom} from 'store';
@@ -114,16 +115,15 @@ export default function ChooseTrainingOptions() {
       </div>
 
       <div className="flex items-center justify-between mt-8">
-        <button
-          className="button"
+        <Button
+          variant="secondary"
           onClick={() => {
             setStage(NewModelStage.Dataset);
           }}
         >
           Back
-        </button>
-        <button
-          className="button"
+        </Button>
+        <Button
           disabled={!isValid()}
           onClick={() => {
             setModel({...model!, options});
@@ -131,7 +131,7 @@ export default function ChooseTrainingOptions() {
           }}
         >
           Next
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/client/src/components/train/DatasetTable.tsx
+++ b/client/src/components/train/DatasetTable.tsx
@@ -1,10 +1,12 @@
 import {useAtom} from 'jotai';
 import fileDownload from 'js-file-download';
 import {deleteDataset, downloadDataset} from 'lib/api/datasets';
-import colours from 'lib/colours';
 import React from 'react';
-import {Download, Trash2} from 'react-feather';
+import {Download, Trash2} from 'lucide-react';
 import {datasetsAtom} from 'store';
+import DataTable, {Section} from 'components/DataTable';
+import Dataset from 'types/Dataset';
+import {Button} from 'components/ui/button';
 
 const DatasetTable: React.FC = () => {
   const [datasets, setDatasets] = useAtom(datasetsAtom);
@@ -29,44 +31,44 @@ const DatasetTable: React.FC = () => {
     }
   };
 
+  const sections: Section<Dataset>[] = [
+    {
+      name: 'Name',
+      display: dataset => <span className="font-semibold">{dataset.name}</span>,
+    },
+    {name: 'Source', display: () => 'Local'},
+    {name: 'File Count', display: dataset => dataset.files.length},
+    {
+      name: 'Download',
+      display: dataset => (
+        <Button
+          size="icon"
+          variant="ghost"
+          onClick={() => _downloadDataset(dataset.name)}
+        >
+          <Download />
+        </Button>
+      ),
+    },
+    {
+      name: 'Delete',
+      display: dataset => (
+        <Button
+          size="icon"
+          variant="ghost"
+          onClick={() => _deleteDataset(dataset.name)}
+        >
+          <Trash2 />
+        </Button>
+      ),
+    },
+  ];
+
   if (datasets.length === 0) {
     return <p>No current datasets!</p>;
   }
 
-  return (
-    <div className="text-left w-full">
-      <table className="w-full table">
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Source</th>
-            <th>Number of Files</th>
-            <th>Download</th>
-            <th>Delete</th>
-          </tr>
-        </thead>
-        <tbody>
-          {datasets.map((dataset, index) => (
-            <tr key={index}>
-              <td>{dataset.name}</td>
-              <td>Local</td>
-              <td>{dataset.files.length}</td>
-              <td>
-                <button onClick={() => _downloadDataset(dataset.name)}>
-                  <Download color={colours.grey} />
-                </button>
-              </td>
-              <td>
-                <button onClick={() => _deleteDataset(dataset.name)}>
-                  <Trash2 color={colours.delete} />
-                </button>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
-  );
+  return <DataTable data={datasets} sections={sections} />;
 };
 
 export default DatasetTable;

--- a/client/src/components/train/ViewTraining.tsx
+++ b/client/src/components/train/ViewTraining.tsx
@@ -5,6 +5,8 @@ import Model, {TrainingStatus} from 'types/Model';
 import Link from 'next/link';
 import {tensorboard} from 'lib/urls';
 import TrainingStatusIndicator from 'components/train/TrainingStatusIndicator';
+import {Button} from 'components/ui/button';
+import {Download} from 'react-feather';
 
 type Props = {
   model: Model;
@@ -68,12 +70,17 @@ const ViewTraining: React.FC<Props> = ({model}) => {
         ))}
       </div>
       <div className="flex space-x-2">
-        <button className="button" onClick={downloadLogs}>
-          Download Logs
-        </button>
+        <Button
+          variant="secondary"
+          className="space-x-2"
+          onClick={downloadLogs}
+        >
+          <Download size={20} />
+          <span>Download Logs</span>
+        </Button>
         <Link href={tensorboard}>
           <a target="_blank">
-            <button className="button">Tensorboard</button>
+            <Button variant="link">Tensorboard</Button>
           </a>
         </Link>
       </div>

--- a/client/src/components/transcribe/TranscriptionFileUpload.tsx
+++ b/client/src/components/transcribe/TranscriptionFileUpload.tsx
@@ -5,6 +5,7 @@ import {useAtom} from 'jotai';
 import {Check, X, Trash2} from 'react-feather';
 import {FileType, parseFileType} from 'lib/dataset';
 import colours from 'lib/colours';
+import {Button} from 'components/ui/button';
 
 export default function TranscriptionFileUpload() {
   const [files, setFiles] = useAtom(transcriptionFilesAtom);
@@ -44,7 +45,9 @@ export default function TranscriptionFileUpload() {
                       )}
                     </td>
                     <td>
-                      <button
+                      <Button
+                        variant="ghost"
+                        size="icon"
                         onClick={() =>
                           setFiles(
                             files.filter((_, _index) => index !== _index)
@@ -52,7 +55,7 @@ export default function TranscriptionFileUpload() {
                         }
                       >
                         <Trash2 color={colours.delete} />
-                      </button>
+                      </Button>
                     </td>
                   </tr>
                 ))}
@@ -60,11 +63,11 @@ export default function TranscriptionFileUpload() {
             </table>
           </div>
           <div className="flex space-x-2 items-center justify-between">
-            <button className="button block" onClick={() => setFiles([])}>
+            <Button variant="secondary" onClick={() => setFiles([])}>
               Reset
-            </button>
-            <button
-              className="button block"
+            </Button>
+            <Button
+              variant="secondary"
               onClick={removeUnsupported}
               disabled={
                 files.filter(
@@ -73,7 +76,7 @@ export default function TranscriptionFileUpload() {
               }
             >
               Remove Unsupported Files
-            </button>
+            </Button>
           </div>
         </>
       )}

--- a/client/src/components/transcribe/TranscriptionsTable.tsx
+++ b/client/src/components/transcribe/TranscriptionsTable.tsx
@@ -22,6 +22,7 @@ import {transcriptionsAtom} from 'store';
 import Transcription, {TranscriptionStatus} from 'types/Transcription';
 import DownloadTranscriptionFileButton from './DownloadTranscriptionFileButton';
 import Link from 'next/link';
+import {Button} from 'components/ui/button';
 
 const DatasetTable: React.FC = () => {
   const [transcriptions, setTranscriptions] = useAtom(transcriptionsAtom);
@@ -129,8 +130,9 @@ const DatasetTable: React.FC = () => {
   return (
     <>
       <div className="mt-2 text-sm flex justify-between">
-        <button
-          className="button"
+        <Button
+          size="sm"
+          variant="outline"
           disabled={
             transcriptions.filter(
               transcription =>
@@ -140,10 +142,11 @@ const DatasetTable: React.FC = () => {
           onClick={downloadAllTranscriptions}
         >
           Download All Transcriptions
-        </button>
+        </Button>
         <div className="space-x-2">
-          <button
-            className="button"
+          <Button
+            size="sm"
+            variant="outline"
             onClick={transcribeEverything}
             disabled={
               transcriptions.filter(
@@ -153,10 +156,10 @@ const DatasetTable: React.FC = () => {
             }
           >
             Transcribe All
-          </button>
-          <button className="button" onClick={removeAll}>
+          </Button>
+          <Button size="sm" variant="outline" onClick={removeAll}>
             Delete All
-          </button>
+          </Button>
         </div>
       </div>
       <div className="text-left w-full">

--- a/client/src/components/ui/badge.tsx
+++ b/client/src/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border border-slate-200 px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 dark:border-slate-800 dark:focus:ring-slate-800",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-slate-900 text-slate-50 hover:bg-slate-900/80 dark:bg-slate-50 dark:text-slate-900 dark:hover:bg-slate-50/80",
+        secondary:
+          "border-transparent bg-slate-100 text-slate-900 hover:bg-slate-100/80 dark:bg-slate-800 dark:text-slate-50 dark:hover:bg-slate-800/80",
+        destructive:
+          "border-transparent bg-red-500 text-slate-50 hover:bg-red-500/80 dark:bg-red-900 dark:text-red-50 dark:hover:bg-red-900/80",
+        outline: "text-slate-950 dark:text-slate-50",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/client/src/components/ui/badge.tsx
+++ b/client/src/components/ui/badge.tsx
@@ -1,36 +1,34 @@
-import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from 'react';
+import {cva, type VariantProps} from 'class-variance-authority';
 
-import { cn } from "lib/utils"
+import {cn} from 'lib/utils';
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-full border border-slate-200 px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 dark:border-slate-800 dark:focus:ring-slate-800",
+  'inline-flex items-center rounded-full border border-slate-200 px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 dark:border-slate-800 dark:focus:ring-slate-800',
   {
     variants: {
       variant: {
         default:
-          "border-transparent bg-slate-900 text-slate-50 hover:bg-slate-900/80 dark:bg-slate-50 dark:text-slate-900 dark:hover:bg-slate-50/80",
+          'border-transparent bg-slate-900 text-slate-50 hover:bg-slate-900/80 dark:bg-slate-50 dark:text-slate-900 dark:hover:bg-slate-50/80',
         secondary:
-          "border-transparent bg-slate-100 text-slate-900 hover:bg-slate-100/80 dark:bg-slate-800 dark:text-slate-50 dark:hover:bg-slate-800/80",
+          'border-transparent bg-slate-100 text-slate-900 hover:bg-slate-100/80 dark:bg-slate-800 dark:text-slate-50 dark:hover:bg-slate-800/80',
         destructive:
-          "border-transparent bg-red-500 text-slate-50 hover:bg-red-500/80 dark:bg-red-900 dark:text-red-50 dark:hover:bg-red-900/80",
-        outline: "text-slate-950 dark:text-slate-50",
+          'border-transparent bg-red-500 text-slate-50 hover:bg-red-500/80 dark:bg-red-900 dark:text-red-50 dark:hover:bg-red-900/80',
+        outline: 'text-slate-950 dark:text-slate-50',
       },
     },
     defaultVariants: {
-      variant: "default",
+      variant: 'default',
     },
   }
-)
+);
 
 export interface BadgeProps
   extends React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof badgeVariants> {}
 
-function Badge({ className, variant, ...props }: BadgeProps) {
-  return (
-    <div className={cn(badgeVariants({ variant }), className)} {...props} />
-  )
+function Badge({className, variant, ...props}: BadgeProps) {
+  return <div className={cn(badgeVariants({variant}), className)} {...props} />;
 }
 
-export { Badge, badgeVariants }
+export {Badge, badgeVariants};

--- a/client/src/components/ui/button.tsx
+++ b/client/src/components/ui/button.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import {Slot} from '@radix-ui/react-slot';
+import {cva, type VariantProps} from 'class-variance-authority';
+
+import {cn} from 'lib/utils';
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 dark:ring-offset-slate-950 dark:focus-visible:ring-slate-800',
+  {
+    variants: {
+      variant: {
+        default:
+          'bg-slate-900 text-slate-50 hover:bg-slate-900/90 dark:bg-slate-50 dark:text-slate-900 dark:hover:bg-slate-50/90',
+        destructive:
+          'bg-red-500 text-slate-50 hover:bg-red-500/90 dark:bg-red-900 dark:text-red-50 dark:hover:bg-red-900/90',
+        outline:
+          'border border-slate-200 bg-white hover:bg-slate-100 hover:text-slate-900 dark:border-slate-800 dark:bg-slate-950 dark:hover:bg-slate-800 dark:hover:text-slate-50',
+        secondary:
+          'bg-slate-100 text-slate-900 hover:bg-slate-100/80 dark:bg-slate-800 dark:text-slate-50 dark:hover:bg-slate-800/80',
+        ghost:
+          'hover:bg-slate-100 hover:text-slate-900 dark:hover:bg-slate-800 dark:hover:text-slate-50',
+        link: 'text-slate-900 underline-offset-4 hover:underline dark:text-slate-50',
+      },
+      size: {
+        default: 'h-10 px-4 py-2',
+        sm: 'h-9 rounded-md px-3',
+        lg: 'h-11 rounded-md px-8',
+        icon: 'h-10 w-10',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({className, variant, size, asChild = false, ...props}, ref) => {
+    const Comp = asChild ? Slot : 'button';
+    return (
+      <Comp
+        className={cn(buttonVariants({variant, size, className}))}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = 'Button';
+
+export {Button, buttonVariants};

--- a/client/src/components/ui/card.tsx
+++ b/client/src/components/ui/card.tsx
@@ -1,0 +1,79 @@
+import * as React from "react"
+
+import { cn } from "lib/utils"
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-lg border border-slate-200 bg-white text-slate-950 shadow-sm dark:border-slate-800 dark:bg-slate-950 dark:text-slate-50",
+      className
+    )}
+    {...props}
+  />
+))
+Card.displayName = "Card"
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+))
+CardHeader.displayName = "CardHeader"
+
+const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn(
+      "text-2xl font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+CardTitle.displayName = "CardTitle"
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn("text-sm text-slate-500 dark:text-slate-400", className)}
+    {...props}
+  />
+))
+CardDescription.displayName = "CardDescription"
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+))
+CardContent.displayName = "CardContent"
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+))
+CardFooter.displayName = "CardFooter"
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }

--- a/client/src/components/ui/card.tsx
+++ b/client/src/components/ui/card.tsx
@@ -1,79 +1,79 @@
-import * as React from "react"
+import * as React from 'react';
 
-import { cn } from "lib/utils"
+import {cn} from 'lib/utils';
 
 const Card = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
+>(({className, ...props}, ref) => (
   <div
     ref={ref}
     className={cn(
-      "rounded-lg border border-slate-200 bg-white text-slate-950 shadow-sm dark:border-slate-800 dark:bg-slate-950 dark:text-slate-50",
+      'rounded-lg border border-slate-200 bg-white text-slate-950 shadow-sm dark:border-slate-800 dark:bg-slate-950 dark:text-slate-50',
       className
     )}
     {...props}
   />
-))
-Card.displayName = "Card"
+));
+Card.displayName = 'Card';
 
 const CardHeader = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
+>(({className, ...props}, ref) => (
   <div
     ref={ref}
-    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    className={cn('flex flex-col space-y-1.5 p-6', className)}
     {...props}
   />
-))
-CardHeader.displayName = "CardHeader"
+));
+CardHeader.displayName = 'CardHeader';
 
 const CardTitle = React.forwardRef<
   HTMLParagraphElement,
   React.HTMLAttributes<HTMLHeadingElement>
->(({ className, ...props }, ref) => (
+>(({className, ...props}, ref) => (
   <h3
     ref={ref}
     className={cn(
-      "text-2xl font-semibold leading-none tracking-tight",
+      'text-2xl font-semibold leading-none tracking-tight',
       className
     )}
     {...props}
   />
-))
-CardTitle.displayName = "CardTitle"
+));
+CardTitle.displayName = 'CardTitle';
 
 const CardDescription = React.forwardRef<
   HTMLParagraphElement,
   React.HTMLAttributes<HTMLParagraphElement>
->(({ className, ...props }, ref) => (
+>(({className, ...props}, ref) => (
   <p
     ref={ref}
-    className={cn("text-sm text-slate-500 dark:text-slate-400", className)}
+    className={cn('text-sm text-slate-500 dark:text-slate-400', className)}
     {...props}
   />
-))
-CardDescription.displayName = "CardDescription"
+));
+CardDescription.displayName = 'CardDescription';
 
 const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
-))
-CardContent.displayName = "CardContent"
+>(({className, ...props}, ref) => (
+  <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />
+));
+CardContent.displayName = 'CardContent';
 
 const CardFooter = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
+>(({className, ...props}, ref) => (
   <div
     ref={ref}
-    className={cn("flex items-center p-6 pt-0", className)}
+    className={cn('flex items-center p-6 pt-0', className)}
     {...props}
   />
-))
-CardFooter.displayName = "CardFooter"
+));
+CardFooter.displayName = 'CardFooter';
 
-export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }
+export {Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent};

--- a/client/src/components/ui/input.tsx
+++ b/client/src/components/ui/input.tsx
@@ -1,0 +1,25 @@
+import * as React from "react"
+
+import { cn } from "lib/utils"
+
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-md border border-slate-200 border-slate-200 bg-white px-3 py-2 text-sm ring-offset-white file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-slate-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-800 dark:border-slate-800 dark:bg-slate-950 dark:ring-offset-slate-950 dark:placeholder:text-slate-400 dark:focus-visible:ring-slate-800",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
+
+export { Input }

--- a/client/src/components/ui/input.tsx
+++ b/client/src/components/ui/input.tsx
@@ -1,25 +1,25 @@
-import * as React from "react"
+import * as React from 'react';
 
-import { cn } from "lib/utils"
+import {cn} from 'lib/utils';
 
 export interface InputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {}
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, ...props }, ref) => {
+  ({className, type, ...props}, ref) => {
     return (
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-slate-200 border-slate-200 bg-white px-3 py-2 text-sm ring-offset-white file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-slate-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-800 dark:border-slate-800 dark:bg-slate-950 dark:ring-offset-slate-950 dark:placeholder:text-slate-400 dark:focus-visible:ring-slate-800",
+          'flex h-10 w-full rounded-md border border-slate-200 border-slate-200 bg-white px-3 py-2 text-sm ring-offset-white file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-slate-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-800 dark:border-slate-800 dark:bg-slate-950 dark:ring-offset-slate-950 dark:placeholder:text-slate-400 dark:focus-visible:ring-slate-800',
           className
         )}
         ref={ref}
         {...props}
       />
-    )
+    );
   }
-)
-Input.displayName = "Input"
+);
+Input.displayName = 'Input';
 
-export { Input }
+export {Input};

--- a/client/src/components/ui/label.tsx
+++ b/client/src/components/ui/label.tsx
@@ -1,0 +1,24 @@
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "lib/utils"
+
+const labelVariants = cva(
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+)
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+    VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(labelVariants(), className)}
+    {...props}
+  />
+))
+Label.displayName = LabelPrimitive.Root.displayName
+
+export { Label }

--- a/client/src/components/ui/label.tsx
+++ b/client/src/components/ui/label.tsx
@@ -1,24 +1,24 @@
-import * as React from "react"
-import * as LabelPrimitive from "@radix-ui/react-label"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from 'react';
+import * as LabelPrimitive from '@radix-ui/react-label';
+import {cva, type VariantProps} from 'class-variance-authority';
 
-import { cn } from "lib/utils"
+import {cn} from 'lib/utils';
 
 const labelVariants = cva(
-  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-)
+  'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70'
+);
 
 const Label = React.forwardRef<
   React.ElementRef<typeof LabelPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
     VariantProps<typeof labelVariants>
->(({ className, ...props }, ref) => (
+>(({className, ...props}, ref) => (
   <LabelPrimitive.Root
     ref={ref}
     className={cn(labelVariants(), className)}
     {...props}
   />
-))
-Label.displayName = LabelPrimitive.Root.displayName
+));
+Label.displayName = LabelPrimitive.Root.displayName;
 
-export { Label }
+export {Label};

--- a/client/src/components/ui/select.tsx
+++ b/client/src/components/ui/select.tsx
@@ -1,23 +1,23 @@
-import * as React from "react"
-import * as SelectPrimitive from "@radix-ui/react-select"
-import { Check, ChevronDown } from "lucide-react"
+import * as React from 'react';
+import * as SelectPrimitive from '@radix-ui/react-select';
+import {Check, ChevronDown} from 'lucide-react';
 
-import { cn } from "lib/utils"
+import {cn} from 'lib/utils';
 
-const Select = SelectPrimitive.Root
+const Select = SelectPrimitive.Root;
 
-const SelectGroup = SelectPrimitive.Group
+const SelectGroup = SelectPrimitive.Group;
 
-const SelectValue = SelectPrimitive.Value
+const SelectValue = SelectPrimitive.Value;
 
 const SelectTrigger = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
->(({ className, children, ...props }, ref) => (
+>(({className, children, ...props}, ref) => (
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 w-full items-center justify-between rounded-md border border-slate-200 border-slate-200 bg-transparent px-3 py-2 text-sm ring-offset-white placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-800 dark:border-slate-800 dark:ring-offset-slate-950 dark:placeholder:text-slate-400 dark:focus:ring-slate-800",
+      'flex h-10 w-full items-center justify-between rounded-md border border-slate-200 border-slate-200 bg-transparent px-3 py-2 text-sm ring-offset-white placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-800 dark:border-slate-800 dark:ring-offset-slate-950 dark:placeholder:text-slate-400 dark:focus:ring-slate-800',
       className
     )}
     {...props}
@@ -27,20 +27,20 @@ const SelectTrigger = React.forwardRef<
       <ChevronDown className="h-4 w-4 opacity-50" />
     </SelectPrimitive.Icon>
   </SelectPrimitive.Trigger>
-))
-SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
+));
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
 
 const SelectContent = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
->(({ className, children, position = "popper", ...props }, ref) => (
+>(({className, children, position = 'popper', ...props}, ref) => (
   <SelectPrimitive.Portal>
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 min-w-[8rem] overflow-hidden rounded-md border border-slate-200 bg-white text-slate-950 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-50",
-        position === "popper" &&
-          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+        'relative z-50 min-w-[8rem] overflow-hidden rounded-md border border-slate-200 bg-white text-slate-950 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-50',
+        position === 'popper' &&
+          'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
         className
       )}
       position={position}
@@ -48,38 +48,38 @@ const SelectContent = React.forwardRef<
     >
       <SelectPrimitive.Viewport
         className={cn(
-          "p-1",
-          position === "popper" &&
-            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+          'p-1',
+          position === 'popper' &&
+            'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]'
         )}
       >
         {children}
       </SelectPrimitive.Viewport>
     </SelectPrimitive.Content>
   </SelectPrimitive.Portal>
-))
-SelectContent.displayName = SelectPrimitive.Content.displayName
+));
+SelectContent.displayName = SelectPrimitive.Content.displayName;
 
 const SelectLabel = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Label>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
->(({ className, ...props }, ref) => (
+>(({className, ...props}, ref) => (
   <SelectPrimitive.Label
     ref={ref}
-    className={cn("py-1.5 pl-8 pr-2 text-sm font-semibold", className)}
+    className={cn('py-1.5 pl-8 pr-2 text-sm font-semibold', className)}
     {...props}
   />
-))
-SelectLabel.displayName = SelectPrimitive.Label.displayName
+));
+SelectLabel.displayName = SelectPrimitive.Label.displayName;
 
 const SelectItem = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
->(({ className, children, ...props }, ref) => (
+>(({className, children, ...props}, ref) => (
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-slate-100 focus:text-slate-900 data-[disabled]:pointer-events-none data-[disabled]:opacity-50 dark:focus:bg-slate-800 dark:focus:text-slate-50",
+      'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-slate-100 focus:text-slate-900 data-[disabled]:pointer-events-none data-[disabled]:opacity-50 dark:focus:bg-slate-800 dark:focus:text-slate-50',
       className
     )}
     {...props}
@@ -92,20 +92,20 @@ const SelectItem = React.forwardRef<
 
     <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
   </SelectPrimitive.Item>
-))
-SelectItem.displayName = SelectPrimitive.Item.displayName
+));
+SelectItem.displayName = SelectPrimitive.Item.displayName;
 
 const SelectSeparator = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Separator>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
->(({ className, ...props }, ref) => (
+>(({className, ...props}, ref) => (
   <SelectPrimitive.Separator
     ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-slate-100 dark:bg-slate-800", className)}
+    className={cn('-mx-1 my-1 h-px bg-slate-100 dark:bg-slate-800', className)}
     {...props}
   />
-))
-SelectSeparator.displayName = SelectPrimitive.Separator.displayName
+));
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
 
 export {
   Select,
@@ -116,4 +116,4 @@ export {
   SelectLabel,
   SelectItem,
   SelectSeparator,
-}
+};

--- a/client/src/components/ui/select.tsx
+++ b/client/src/components/ui/select.tsx
@@ -1,0 +1,119 @@
+import * as React from "react"
+import * as SelectPrimitive from "@radix-ui/react-select"
+import { Check, ChevronDown } from "lucide-react"
+
+import { cn } from "lib/utils"
+
+const Select = SelectPrimitive.Root
+
+const SelectGroup = SelectPrimitive.Group
+
+const SelectValue = SelectPrimitive.Value
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "flex h-10 w-full items-center justify-between rounded-md border border-slate-200 border-slate-200 bg-transparent px-3 py-2 text-sm ring-offset-white placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-800 dark:border-slate-800 dark:ring-offset-slate-950 dark:placeholder:text-slate-400 dark:focus:ring-slate-800",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+))
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
+
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = "popper", ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        "relative z-50 min-w-[8rem] overflow-hidden rounded-md border border-slate-200 bg-white text-slate-950 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-50",
+        position === "popper" &&
+          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+        className
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectPrimitive.Viewport
+        className={cn(
+          "p-1",
+          position === "popper" &&
+            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+))
+SelectContent.displayName = SelectPrimitive.Content.displayName
+
+const SelectLabel = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn("py-1.5 pl-8 pr-2 text-sm font-semibold", className)}
+    {...props}
+  />
+))
+SelectLabel.displayName = SelectPrimitive.Label.displayName
+
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-slate-100 focus:text-slate-900 data-[disabled]:pointer-events-none data-[disabled]:opacity-50 dark:focus:bg-slate-800 dark:focus:text-slate-50",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+))
+SelectItem.displayName = SelectPrimitive.Item.displayName
+
+const SelectSeparator = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-slate-100 dark:bg-slate-800", className)}
+    {...props}
+  />
+))
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName
+
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+}

--- a/client/src/components/ui/table.tsx
+++ b/client/src/components/ui/table.tsx
@@ -1,0 +1,117 @@
+import * as React from 'react';
+
+import {cn} from 'lib/utils';
+
+const Table = React.forwardRef<
+  HTMLTableElement,
+  React.HTMLAttributes<HTMLTableElement>
+>(({className, ...props}, ref) => (
+  <div className="w-full overflow-auto">
+    <table
+      ref={ref}
+      className={cn('w-full caption-bottom text-sm', className)}
+      {...props}
+    />
+  </div>
+));
+Table.displayName = 'Table';
+
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({className, ...props}, ref) => (
+  <thead ref={ref} className={cn('[&_tr]:border-b', className)} {...props} />
+));
+TableHeader.displayName = 'TableHeader';
+
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({className, ...props}, ref) => (
+  <tbody
+    ref={ref}
+    className={cn('[&_tr:last-child]:border-0', className)}
+    {...props}
+  />
+));
+TableBody.displayName = 'TableBody';
+
+const TableFooter = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({className, ...props}, ref) => (
+  <tfoot
+    ref={ref}
+    className={cn(
+      'bg-slate-900 font-medium text-slate-50 dark:bg-slate-50 dark:text-slate-900',
+      className
+    )}
+    {...props}
+  />
+));
+TableFooter.displayName = 'TableFooter';
+
+const TableRow = React.forwardRef<
+  HTMLTableRowElement,
+  React.HTMLAttributes<HTMLTableRowElement>
+>(({className, ...props}, ref) => (
+  <tr
+    ref={ref}
+    className={cn(
+      'border-b transition-colors hover:bg-slate-100/50 data-[state=selected]:bg-slate-100 dark:hover:bg-slate-800/50 dark:data-[state=selected]:bg-slate-800',
+      className
+    )}
+    {...props}
+  />
+));
+TableRow.displayName = 'TableRow';
+
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({className, ...props}, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      'h-12 px-4 text-left align-middle font-medium text-slate-500 [&:has([role=checkbox])]:pr-0 dark:text-slate-400',
+      className
+    )}
+    {...props}
+  />
+));
+TableHead.displayName = 'TableHead';
+
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({className, ...props}, ref) => (
+  <td
+    ref={ref}
+    className={cn('p-4 align-middle [&:has([role=checkbox])]:pr-0', className)}
+    {...props}
+  />
+));
+TableCell.displayName = 'TableCell';
+
+const TableCaption = React.forwardRef<
+  HTMLTableCaptionElement,
+  React.HTMLAttributes<HTMLTableCaptionElement>
+>(({className, ...props}, ref) => (
+  <caption
+    ref={ref}
+    className={cn('mt-4 text-sm text-slate-500 dark:text-slate-400', className)}
+    {...props}
+  />
+));
+TableCaption.displayName = 'TableCaption';
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+};

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import {ClassValue, clsx} from 'clsx';
+import {twMerge} from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/client/src/pages/datasets.tsx
+++ b/client/src/pages/datasets.tsx
@@ -7,7 +7,8 @@ import {getDatasets} from 'lib/api/datasets';
 import Link from 'next/link';
 import urls from 'lib/urls';
 import ClientOnly from 'components/ClientOnly';
-import { Button } from 'components/ui/button';
+import {Button} from 'components/ui/button';
+import {Plus} from 'lucide-react';
 
 const DatasetsPage: NextPage = () => {
   const [datasets, setDatasets] = useAtom(datasetsAtom);
@@ -31,12 +32,13 @@ const DatasetsPage: NextPage = () => {
       <p className="mt-2 page-description">Blah blah blah</p>
 
       <ClientOnly className="mt-8 space-y-4">
-        <p className="subtitle">Your Datasets</p>
-        <DatasetTable />
-        <div className="space-x-2 mt-2 flex justify-between">
+        <div className="space-x-2 mt-2 flex">
           <Link href={urls.datasets.new}>
             <a>
-              <Button>Create new</Button>
+              <Button>
+                <Plus className="mr-2 h-4 w-4" />
+                Create new
+              </Button>
             </a>
           </Link>
           {datasets.length > 0 && (
@@ -47,6 +49,8 @@ const DatasetsPage: NextPage = () => {
             </Link>
           )}
         </div>
+        <p className="subtitle">Your Datasets</p>
+        <DatasetTable />
       </ClientOnly>
     </div>
   );

--- a/client/src/pages/datasets.tsx
+++ b/client/src/pages/datasets.tsx
@@ -7,6 +7,7 @@ import {getDatasets} from 'lib/api/datasets';
 import Link from 'next/link';
 import urls from 'lib/urls';
 import ClientOnly from 'components/ClientOnly';
+import { Button } from 'components/ui/button';
 
 const DatasetsPage: NextPage = () => {
   const [datasets, setDatasets] = useAtom(datasetsAtom);
@@ -35,13 +36,13 @@ const DatasetsPage: NextPage = () => {
         <div className="space-x-2 mt-2 flex justify-between">
           <Link href={urls.datasets.new}>
             <a>
-              <button className="button">Create new</button>
+              <Button>Create new</Button>
             </a>
           </Link>
           {datasets.length > 0 && (
             <Link href={urls.train.new}>
               <a>
-                <button className="button">Train Model</button>
+                <Button variant="secondary">Train Model</Button>
               </a>
             </Link>
           )}

--- a/client/src/pages/datasets/new.tsx
+++ b/client/src/pages/datasets/new.tsx
@@ -15,6 +15,7 @@ import {createDataset} from 'lib/api/datasets';
 import {useRouter} from 'next/router';
 import urls from 'lib/urls';
 import {isValidForDataset} from 'lib/dataset';
+import {Button} from 'components/ui/button';
 
 const NewDatasetPage: React.FC = () => {
   const router = useRouter();
@@ -71,9 +72,9 @@ const NewDatasetPage: React.FC = () => {
       <ChooseDatasetName />
 
       <div className="flex justify-end">
-        <button className="button" onClick={save} disabled={!canCreate()}>
+        <Button onClick={save} disabled={!canCreate()}>
           Save
-        </button>
+        </Button>
       </div>
 
       {error && <p className="text-red-400">{error}</p>}

--- a/client/src/pages/datasets/new.tsx
+++ b/client/src/pages/datasets/new.tsx
@@ -66,10 +66,10 @@ const NewDatasetPage: React.FC = () => {
       <h1 className="text-3xl">New Dataset</h1>
       <p className="page-description">Some description</p>
 
+      <ChooseDatasetName />
       <DatasetFiles />
       <ChooseElanOptions />
       <ChooseCleaningOptions />
-      <ChooseDatasetName />
 
       <div className="flex justify-end">
         <Button onClick={save} disabled={!canCreate()}>

--- a/client/src/pages/train.tsx
+++ b/client/src/pages/train.tsx
@@ -8,6 +8,7 @@ import Link from 'next/link';
 import urls from 'lib/urls';
 import {TrainingStatus} from 'types/Model';
 import ClientOnly from 'components/ClientOnly';
+import {Button} from 'components/ui/button';
 
 const TrainPage: NextPage = () => {
   const [models, setModels] = useAtom(modelsAtom);
@@ -39,12 +40,12 @@ const TrainPage: NextPage = () => {
               <div className="space-x-2">
                 <Link href={urls.train.new}>
                   <a>
-                    <button className="button">Create New</button>
+                    <Button>Create New</Button>
                   </a>
                 </Link>
                 <Link href={urls.train.upload}>
                   <a>
-                    <button className="button">Upload Model</button>
+                    <Button variant="outline">Upload Model</Button>
                   </a>
                 </Link>
               </div>
@@ -54,7 +55,7 @@ const TrainPage: NextPage = () => {
                 <div>
                   <Link href={urls.transcriptions.new}>
                     <a>
-                      <button className="button">Transcribe Audio</button>
+                      <Button variant="outline">Transcribe Audio</Button>
                     </a>
                   </Link>
                 </div>

--- a/client/src/pages/train/view/[modelName].tsx
+++ b/client/src/pages/train/view/[modelName].tsx
@@ -1,5 +1,6 @@
 import ViewModelInfo from 'components/train/ViewModelInfo';
 import ViewTraining from 'components/train/ViewTraining';
+import {Button} from 'components/ui/button';
 import {useAtom} from 'jotai';
 import urls from 'lib/urls';
 import Link from 'next/link';
@@ -32,7 +33,7 @@ export default function ViewModelPage() {
         </p>
         <Link href={urls.train.index}>
           <a>
-            <button className="button mt-4">Models Page</button>
+            <Button>Models Page</Button>
           </a>
         </Link>
       </div>
@@ -43,14 +44,18 @@ export default function ViewModelPage() {
     <div className="container">
       <h1 className="title mb-4">View Model: {modelName}</h1>
 
+      <Button
+        variant="secondary"
+        className="mb-2"
+        onClick={() => setShowInfo(!showInfo)}
+      >
+        {showInfo ? 'Hide Model Info' : 'Show Model Info'}
+      </Button>
+
       {/** Model info section */}
       <div className={'section space-y-4 ' + (!showInfo && 'hidden')}>
         <ViewModelInfo model={model} />
       </div>
-
-      <button className="button mt-2" onClick={() => setShowInfo(!showInfo)}>
-        {showInfo ? 'Hide Model Info' : 'Show Model Info'}
-      </button>
 
       <ViewTraining model={model} />
     </div>

--- a/client/src/pages/transcriptions.tsx
+++ b/client/src/pages/transcriptions.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link';
 import urls from 'lib/urls';
 import Transcription from 'types/Transcription';
 import ClientOnly from 'components/ClientOnly';
+import {Button} from 'components/ui/button';
 
 export default function TranscriptionsPage() {
   const [, setTranscriptions] = useAtom(transcriptionsAtom);
@@ -36,7 +37,7 @@ export default function TranscriptionsPage() {
       <div className="mt-4">
         <Link href={urls.transcriptions.new}>
           <a>
-            <button className="button">Create New</button>
+            <Button>Create New</Button>
           </a>
         </Link>
       </div>

--- a/client/src/pages/transcriptions/new.tsx
+++ b/client/src/pages/transcriptions/new.tsx
@@ -13,6 +13,7 @@ import TranscriptionFileUpload from 'components/transcribe/TranscriptionFileUplo
 import {useRouter} from 'next/router';
 import urls from 'lib/urls';
 import {FileType, parseFileType} from 'lib/dataset';
+import { Button } from 'components/ui/button';
 
 export default function TranscribePage() {
   const router = useRouter();
@@ -67,13 +68,12 @@ export default function TranscribePage() {
       <TranscriptionFileUpload />
 
       <div className="flex justify-end">
-        <button
-          className="button"
+        <Button
           onClick={_createTranscriptions}
           disabled={!canAddTranscriptions}
         >
           Transcribe
-        </button>
+        </Button>
       </div>
 
       {error && <p className="text-red-500">{error}</p>}

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -1,16 +1,40 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ['./src/**/*.{jsx,tsx}'],
+  darkMode: ['class'],
+  content: [
+    './pages/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}',
+    './app/**/*.{ts,tsx}',
+    './src/**/*.{ts,tsx}',
+  ],
   theme: {
+    container: {
+      center: true,
+      padding: '2rem',
+      screens: {
+        '2xl': '1400px',
+      },
+    },
     extend: {
       colors: {
         primary: '#662b91',
         secondary: '#262264',
       },
+      keyframes: {
+        'accordion-down': {
+          from: {height: 0},
+          to: {height: 'var(--radix-accordion-content-height)'},
+        },
+        'accordion-up': {
+          from: {height: 'var(--radix-accordion-content-height)'},
+          to: {height: 0},
+        },
+      },
+      animation: {
+        'accordion-down': 'accordion-down 0.2s ease-out',
+        'accordion-up': 'accordion-up 0.2s ease-out',
+      },
     },
   },
-  plugins: [
-    require('@tailwindcss/forms'),
-    // ...
-  ],
+  plugins: [require('@tailwindcss/forms'), require('tailwindcss-animate')],
 };

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -45,6 +45,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.13.10":
+  version "7.22.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.6.tgz#57d64b9ae3cff1d67eb067ae117dac087f5bd438"
+  integrity sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==
+  dependencies:
+    regenerator-runtime "^0.13.11"
+
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.3.tgz#9e42981ef035beb3dd49add17acb96e8ff6f394c"
@@ -200,6 +207,21 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
+
+"@radix-ui/react-compose-refs@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz#7ed868b66946aa6030e580b1ffca386dd4d21989"
+  integrity sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-slot@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.0.2.tgz#a9ff4423eade67f501ffb32ec22064bc9d3099ab"
+  integrity sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "1.0.1"
 
 "@rushstack/eslint-patch@^1.1.3":
   version "1.2.0"
@@ -712,6 +734,13 @@ chownr@^1.1.1:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
   integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
 
+class-variance-authority@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/class-variance-authority/-/class-variance-authority-0.6.1.tgz#9482856c1496d33c21ef19e65b5d255460aa8039"
+  integrity sha512-eurOEGc7YVx3majOrOb099PNKgO3KnKSApOprXI4BTq6bcfbqbQXPN2u+rPPmIJ2di23bMwhk0SxCCthBmszEQ==
+  dependencies:
+    clsx "1.2.1"
+
 cli-cursor@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-3.1.0.tgz#264305a7ae490d1d03bf0c9ba7c925d1753af307"
@@ -723,6 +752,11 @@ cli-width@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
   integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
+
+clsx@1.2.1, clsx@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
+  integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
 
 color-convert@^1.9.0:
   version "1.9.3"
@@ -2055,6 +2089,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lucide-react@^0.259.0:
+  version "0.259.0"
+  resolved "https://registry.yarnpkg.com/lucide-react/-/lucide-react-0.259.0.tgz#7d9ef054e74cbed4bd10943dbac772ce4b89a68e"
+  integrity sha512-dFBLc6jRDfcpD9NQ7NyFVa+YR3RHX6+bs+f/UiotvNPho+kd4WyeXWMCCchUf7i/pq3BAaHkbmtkbx/GxxHVUw==
+
 map-obj@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
@@ -2688,6 +2727,11 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
+regenerator-runtime@^0.13.11:
+  version "0.13.11"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
+  integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
+
 regenerator-runtime@^0.13.4:
   version "0.13.10"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz#ed07b19616bcbec5da6274ebc75ae95634bfc2ee"
@@ -3044,6 +3088,16 @@ table@^6.0.9:
     slice-ansi "^4.0.0"
     string-width "^4.2.3"
     strip-ansi "^6.0.1"
+
+tailwind-merge@^1.13.2:
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/tailwind-merge/-/tailwind-merge-1.13.2.tgz#1d06c9e95ffda2320efc50ed33c65be0cda23091"
+  integrity sha512-R2/nULkdg1VR/EL4RXg4dEohdoxNUJGLMnWIQnPKL+O9Twu7Cn3Rxi4dlXkDzZrEGtR+G+psSXFouWlpTyLhCQ==
+
+tailwindcss-animate@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/tailwindcss-animate/-/tailwindcss-animate-1.0.6.tgz#c7195037481552cc47962ea50113830360fd0c28"
+  integrity sha512-4WigSGMvbl3gCCact62ZvOngA+PRqhAn7si3TQ3/ZuPuQZcIEtVap+ENSXbzWhpojKB8CpvnIsrwBu8/RnHtuw==
 
 tailwindcss@^3.2.1:
   version "3.2.1"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -82,6 +82,25 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
+"@floating-ui/core@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.3.1.tgz#4d795b649cc3b1cbb760d191c80dcb4353c9a366"
+  integrity sha512-Bu+AMaXNjrpjh41znzHqaz3r2Nr8hHuHZT6V2LBKMhyMl0FgKA62PNYbqnfgmzOhoWZj70Zecisbo4H1rotP5g==
+
+"@floating-ui/dom@^1.3.0":
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.4.4.tgz#cf859dde33995a4e7b6ded16c98cb73b2ebfffd0"
+  integrity sha512-21hhDEPOiWkGp0Ys4Wi6Neriah7HweToKra626CIK712B5m9qkdz54OP9gVldUg+URnBTpv/j/bi/skmGdstXQ==
+  dependencies:
+    "@floating-ui/core" "^1.3.1"
+
+"@floating-ui/react-dom@^2.0.0":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.0.1.tgz#7972a4fc488a8c746cded3cfe603b6057c308a91"
+  integrity sha512-rZtAmSht4Lry6gdhAJDrCp/6rKN7++JnL1/Anbr/DdeyYXQPxvg/ivrbYvJulbRf4vL8b212suwMM2lxbv+RQA==
+  dependencies:
+    "@floating-ui/dom" "^1.3.0"
+
 "@humanwhocodes/config-array@^0.11.6":
   version "0.11.6"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.6.tgz#6a51d603a3aaf8d4cf45b42b3f2ac9318a4adc4b"
@@ -208,6 +227,39 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@radix-ui/number@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/number/-/number-1.0.1.tgz#644161a3557f46ed38a042acf4a770e826021674"
+  integrity sha512-T5gIdVO2mmPW3NNhjNgEP3cqMXjXL9UbO0BzWcXfvdBs+BohbQxvd/K5hSVKmn9/lbTdsQVKbUcP5WLCwvUbBg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/primitive@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.0.1.tgz#e46f9958b35d10e9f6dc71c497305c22e3e55dbd"
+  integrity sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-arrow@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-arrow/-/react-arrow-1.0.3.tgz#c24f7968996ed934d57fe6cde5d6ec7266e1d25d"
+  integrity sha512-wSP+pHsB/jQRaL6voubsQ/ZlrGBHHrOjmBnr19hxYgtS0WvAFwZhK2WP/YY5yF9uKECCEEDGxuLxq1NBK51wFA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-primitive" "1.0.3"
+
+"@radix-ui/react-collection@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-collection/-/react-collection-1.0.3.tgz#9595a66e09026187524a36c6e7e9c7d286469159"
+  integrity sha512-3SzW+0PW7yBBoQlT8wNcGtaxaD0XSu0uLUFgrtHY08Acx05TaHaOmVLR73c0j/cqpDy53KBMO7s0dx2wmOIDIA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-slot" "1.0.2"
+
 "@radix-ui/react-compose-refs@1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz#7ed868b66946aa6030e580b1ffca386dd4d21989"
@@ -215,13 +267,201 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
-"@radix-ui/react-slot@^1.0.2":
+"@radix-ui/react-context@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.0.1.tgz#fe46e67c96b240de59187dcb7a1a50ce3e2ec00c"
+  integrity sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-direction@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-direction/-/react-direction-1.0.1.tgz#9cb61bf2ccf568f3421422d182637b7f47596c9b"
+  integrity sha512-RXcvnXgyvYvBEOhCBuddKecVkoMiI10Jcm5cTI7abJRAHYfFxeu+FBQs/DvdxSYucxR5mna0dNsL6QFlds5TMA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-dismissable-layer@1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.4.tgz#883a48f5f938fa679427aa17fcba70c5494c6978"
+  integrity sha512-7UpBa/RKMoHJYjie1gkF1DlK8l1fdU/VKDpoS3rCCo8YBJR294GwcEHyxHw72yvphJ7ld0AXEcSLAzY2F/WyCg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+    "@radix-ui/react-use-escape-keydown" "1.0.3"
+
+"@radix-ui/react-focus-guards@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-guards/-/react-focus-guards-1.0.1.tgz#1ea7e32092216b946397866199d892f71f7f98ad"
+  integrity sha512-Rect2dWbQ8waGzhMavsIbmSVCgYxkXLxxR3ZvCX79JOglzdEy4JXMb98lq4hPxUbLr77nP0UOGf4rcMU+s1pUA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-focus-scope@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-scope/-/react-focus-scope-1.0.3.tgz#9c2e8d4ed1189a1d419ee61edd5c1828726472f9"
+  integrity sha512-upXdPfqI4islj2CslyfUBNlaJCPybbqRHAi1KER7Isel9Q2AtSJ0zRBZv8mWQiFXD2nyAJ4BhC3yXgZ6kMBSrQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+
+"@radix-ui/react-id@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-id/-/react-id-1.0.1.tgz#73cdc181f650e4df24f0b6a5b7aa426b912c88c0"
+  integrity sha512-tI7sT/kqYp8p96yGWY1OAnLHrqDgzHefRBKQ2YAkBS5ja7QLcZ9Z/uY7bEjPUatf8RomoXM8/1sMj1IJaE5UzQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-layout-effect" "1.0.1"
+
+"@radix-ui/react-label@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-label/-/react-label-2.0.2.tgz#9c72f1d334aac996fdc27b48a8bdddd82108fb6d"
+  integrity sha512-N5ehvlM7qoTLx7nWPodsPYPgMzA5WM8zZChQg8nyFJKnDO5WHdba1vv5/H6IO5LtJMfD2Q3wh1qHFGNtK0w3bQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-primitive" "1.0.3"
+
+"@radix-ui/react-popper@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-popper/-/react-popper-1.1.2.tgz#4c0b96fcd188dc1f334e02dba2d538973ad842e9"
+  integrity sha512-1CnGGfFi/bbqtJZZ0P/NQY20xdG3E0LALJaLUEoKwPLwl6PPPfbeiCqMVQnhoFRAxjJj4RpBRJzDmUgsex2tSg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@floating-ui/react-dom" "^2.0.0"
+    "@radix-ui/react-arrow" "1.0.3"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+    "@radix-ui/react-use-layout-effect" "1.0.1"
+    "@radix-ui/react-use-rect" "1.0.1"
+    "@radix-ui/react-use-size" "1.0.1"
+    "@radix-ui/rect" "1.0.1"
+
+"@radix-ui/react-portal@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-portal/-/react-portal-1.0.3.tgz#ffb961244c8ed1b46f039e6c215a6c4d9989bda1"
+  integrity sha512-xLYZeHrWoPmA5mEKEfZZevoVRK/Q43GfzRXkWV6qawIWWK8t6ifIiLQdd7rmQ4Vk1bmI21XhqF9BN3jWf+phpA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-primitive" "1.0.3"
+
+"@radix-ui/react-primitive@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-1.0.3.tgz#d49ea0f3f0b2fe3ab1cb5667eb03e8b843b914d0"
+  integrity sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-slot" "1.0.2"
+
+"@radix-ui/react-select@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-select/-/react-select-1.2.2.tgz#caa981fa0d672cf3c1b2a5240135524e69b32181"
+  integrity sha512-zI7McXr8fNaSrUY9mZe4x/HC0jTLY9fWNhO1oLWYMQGDXuV4UCivIGTxwioSzO0ZCYX9iSLyWmAh/1TOmX3Cnw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/number" "1.0.1"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-collection" "1.0.3"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-direction" "1.0.1"
+    "@radix-ui/react-dismissable-layer" "1.0.4"
+    "@radix-ui/react-focus-guards" "1.0.1"
+    "@radix-ui/react-focus-scope" "1.0.3"
+    "@radix-ui/react-id" "1.0.1"
+    "@radix-ui/react-popper" "1.1.2"
+    "@radix-ui/react-portal" "1.0.3"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-slot" "1.0.2"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+    "@radix-ui/react-use-layout-effect" "1.0.1"
+    "@radix-ui/react-use-previous" "1.0.1"
+    "@radix-ui/react-visually-hidden" "1.0.3"
+    aria-hidden "^1.1.1"
+    react-remove-scroll "2.5.5"
+
+"@radix-ui/react-slot@1.0.2", "@radix-ui/react-slot@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.0.2.tgz#a9ff4423eade67f501ffb32ec22064bc9d3099ab"
   integrity sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==
   dependencies:
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-compose-refs" "1.0.1"
+
+"@radix-ui/react-use-callback-ref@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.1.tgz#f4bb1f27f2023c984e6534317ebc411fc181107a"
+  integrity sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-use-controllable-state@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.1.tgz#ecd2ced34e6330caf89a82854aa2f77e07440286"
+  integrity sha512-Svl5GY5FQeN758fWKrjM6Qb7asvXeiZltlT4U2gVfl8Gx5UAv2sMR0LWo8yhsIZh2oQ0eFdZ59aoOOMV7b47VA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+
+"@radix-ui/react-use-escape-keydown@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.0.3.tgz#217b840c250541609c66f67ed7bab2b733620755"
+  integrity sha512-vyL82j40hcFicA+M4Ex7hVkB9vHgSse1ZWomAqV2Je3RleKGO5iM8KMOEtfoSB0PnIelMd2lATjTGMYqN5ylTg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+
+"@radix-ui/react-use-layout-effect@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.1.tgz#be8c7bc809b0c8934acf6657b577daf948a75399"
+  integrity sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-use-previous@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-previous/-/react-use-previous-1.0.1.tgz#b595c087b07317a4f143696c6a01de43b0d0ec66"
+  integrity sha512-cV5La9DPwiQ7S0gf/0qiD6YgNqM5Fk97Kdrlc5yBcrF3jyEZQwm7vYFqMo4IfeHgJXsRaMvLABFtd0OVEmZhDw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-use-rect@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-rect/-/react-use-rect-1.0.1.tgz#fde50b3bb9fd08f4a1cd204572e5943c244fcec2"
+  integrity sha512-Cq5DLuSiuYVKNU8orzJMbl15TXilTnJKUCltMVQg53BQOF1/C5toAaGrowkgksdBQ9H+SRL23g0HDmg9tvmxXw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/rect" "1.0.1"
+
+"@radix-ui/react-use-size@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-size/-/react-use-size-1.0.1.tgz#1c5f5fea940a7d7ade77694bb98116fb49f870b2"
+  integrity sha512-ibay+VqrgcaI6veAojjofPATwledXiSmX+C0KrBk/xgpX9rBzPV3OsfwlhQdUOFbh+LKQorLYT+xTXW9V8yd0g==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-layout-effect" "1.0.1"
+
+"@radix-ui/react-visually-hidden@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.0.3.tgz#51aed9dd0fe5abcad7dee2a234ad36106a6984ac"
+  integrity sha512-D4w41yN5YRKtu464TLnByKzMDG/JlMPHtfZgQAu9v6mNakUqGUI9vUrfQKz8NK41VMm/xbZbh76NUTVtIYqOMA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-primitive" "1.0.3"
+
+"@radix-ui/rect@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/rect/-/rect-1.0.1.tgz#bf8e7d947671996da2e30f4904ece343bc4a883f"
+  integrity sha512-fyrgCaedtvMg9NK3en0pnOYJdtfwxUcNolezkNPUsoX57X8oQk+NkqcvzHXD2uKNij6GXmWU9NDru2IWjrO4BQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
 
 "@rushstack/eslint-patch@^1.1.3":
   version "1.2.0"
@@ -511,6 +751,13 @@ argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
+aria-hidden@^1.1.1:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/aria-hidden/-/aria-hidden-1.2.3.tgz#14aeb7fb692bbb72d69bebfa47279c1fd725e954"
+  integrity sha512-xcLxITLe2HYa1cnYnwCjkOO1PqUHQpozB8x9AR0OgWN2woOBi5kSDVxKfd0b7sb1hw5qFeJhXm9H1nu3xSfLeQ==
+  dependencies:
+    tslib "^2.0.0"
 
 aria-query@^4.2.2:
   version "4.2.2"
@@ -900,6 +1147,11 @@ detect-libc@^2.0.0, detect-libc@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.0.1.tgz#e1897aa88fa6ad197862937fbc0441ef352ee0cd"
   integrity sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==
+
+detect-node-es@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/detect-node-es/-/detect-node-es-1.1.0.tgz#163acdf643330caa0b4cd7c21e7ee7755d6fa493"
+  integrity sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==
 
 detective@^5.2.1:
   version "5.2.1"
@@ -1540,6 +1792,11 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1, get-intrinsic@
     has "^1.0.3"
     has-symbols "^1.0.3"
 
+get-nonce@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/get-nonce/-/get-nonce-1.0.1.tgz#fdf3f0278073820d2ce9426c18f07481b1e0cdf3"
+  integrity sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==
+
 get-stream@^6.0.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
@@ -1789,6 +2046,13 @@ internal-slot@^1.0.3:
     get-intrinsic "^1.1.0"
     has "^1.0.3"
     side-channel "^1.0.4"
+
+invariant@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
+  integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
+  dependencies:
+    loose-envify "^1.0.0"
 
 is-arrayish@^0.2.1:
   version "0.2.1"
@@ -2075,7 +2339,7 @@ lodash@^4.17.19:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -2670,6 +2934,34 @@ react-is@^16.13.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-remove-scroll-bar@^2.3.3:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.4.tgz#53e272d7a5cb8242990c7f144c44d8bd8ab5afd9"
+  integrity sha512-63C4YQBUt0m6ALadE9XV56hV8BgJWDmmTPY758iIJjfQKt2nYwoUrPk0LXRXcB/yIj82T1/Ixfdpdk68LwIB0A==
+  dependencies:
+    react-style-singleton "^2.2.1"
+    tslib "^2.0.0"
+
+react-remove-scroll@2.5.5:
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.5.5.tgz#1e31a1260df08887a8a0e46d09271b52b3a37e77"
+  integrity sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==
+  dependencies:
+    react-remove-scroll-bar "^2.3.3"
+    react-style-singleton "^2.2.1"
+    tslib "^2.1.0"
+    use-callback-ref "^1.3.0"
+    use-sidecar "^1.1.2"
+
+react-style-singleton@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/react-style-singleton/-/react-style-singleton-2.2.1.tgz#f99e420492b2d8f34d38308ff660b60d0b1205b4"
+  integrity sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==
+  dependencies:
+    get-nonce "^1.0.0"
+    invariant "^2.2.4"
+    tslib "^2.0.0"
+
 react@18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
@@ -3193,6 +3485,11 @@ tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
+tslib@^2.0.0, tslib@^2.1.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.0.tgz#b295854684dbda164e181d259a22cd779dcd7bc3"
+  integrity sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==
+
 tslib@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
@@ -3280,6 +3577,21 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+use-callback-ref@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.3.0.tgz#772199899b9c9a50526fedc4993fc7fa1f7e32d5"
+  integrity sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==
+  dependencies:
+    tslib "^2.0.0"
+
+use-sidecar@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/use-sidecar/-/use-sidecar-1.1.2.tgz#2f43126ba2d7d7e117aa5855e5d8f0276dfe73c2"
+  integrity sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==
+  dependencies:
+    detect-node-es "^1.1.0"
+    tslib "^2.0.0"
 
 use-sync-external-store@1.2.0:
   version "1.2.0"


### PR DESCRIPTION
## Overview
We're migrating to https://ui.shadcn.com/ for a more unified UX experience with all required accessibility already built in. 
I'm also expecting this to reduce development time on new components and increase visual consistency across the app.

This library is also built on tailwindcss, so we can still use tailwind for inline-styling, there just ends up being a lot less of it.

Basic style comparisons:
NEW TABLES
<img width="1273" alt="Screenshot 2023-07-14 at 3 08 14 pm" src="https://github.com/CoEDL/elpis_next/assets/24891460/a3061d1e-8ba1-44c3-a202-92ca560c9b98">

OLD TABLE WITH NEW BUTTONS
<img width="1168" alt="Screenshot 2023-07-14 at 3 08 50 pm" src="https://github.com/CoEDL/elpis_next/assets/24891460/aabd1c12-1207-485f-b3d9-6e7bafea34d0">

## Features
- Replaced all buttons across the app with the new `Button` component.
- Added a bunch of UI primitivies to `src/components/ui`
- Created `DataTable` component, which should make our lives a lot easier by reducing a lot of boilerplate between pages.
- Replaced all the components in the Datasets views with the new UI. 


