### PR TITLE
UI overhaul (transcription flow)

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -20,6 +20,7 @@
     "@radix-ui/react-select": "^1.2.2",
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-switch": "^1.0.3",
+    "@radix-ui/react-tabs": "^1.0.4",
     "class-variance-authority": "^0.6.1",
     "clsx": "^1.2.1",
     "jotai": "^1.8.6",

--- a/client/src/components/transcribe/ChooseHuggingFaceModel.tsx
+++ b/client/src/components/transcribe/ChooseHuggingFaceModel.tsx
@@ -1,4 +1,15 @@
+import {Button} from 'components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from 'components/ui/card';
+import {Input} from 'components/ui/input';
+import {Label} from 'components/ui/label';
 import {useAtom} from 'jotai';
+import {RotateCcw} from 'lucide-react';
 import React from 'react';
 import {modelLocationAtom} from 'store';
 import {BASE_MODEL} from 'types/Model';
@@ -7,25 +18,49 @@ export default function ChooseHuggingFaceModel() {
   const [modelLocation, setModelLocation] = useAtom(modelLocationAtom);
 
   return (
-    <div className="">
-      <h2 className="text-lg font-light">HuggingFace Model Name</h2>
-      <p className="mt-2 text-sm text-gray-700">Description</p>
+    <Card className="">
+      <CardHeader>
+        <CardTitle>Choose HuggingFace Model</CardTitle>
+        <CardDescription>
+          Use a pretrained model from HuggingFace. Available models can be found{' '}
+          <a
+            href="https://huggingface.co/models?pipeline_tag=automatic-speech-recognition"
+            target="_blank"
+            rel="noreferrer"
+            className="underline text-blue-500"
+          >
+            here.
+          </a>
+        </CardDescription>
+        <CardDescription>
+          Model names must be of the form:{' '}
+          <code>&quot;&#123;researchers&#125;/&#123;modelName&#125;&quot;</code>
+          , e.g.
+          <code>facebook/wav2vec2-base-960h</code>.
+        </CardDescription>
+      </CardHeader>
 
-      <div className="mt-4 text-sm flex items-center space-x-4">
-        <label htmlFor="hfLocation" className="font-semibold">
-          Model Name:
-        </label>
-        <input
-          id="hfLocation"
-          className="flex-1"
-          type="text"
-          value={modelLocation}
-          onChange={e => setModelLocation(e.target.value)}
-        />
-        <button className="button" onClick={() => setModelLocation(BASE_MODEL)}>
-          Default
-        </button>
-      </div>
-    </div>
+      <CardContent>
+        <Label htmlFor="hfLocation" className="font-semibold">
+          🤗 Model Name
+        </Label>
+        <div className="flex space-x-2 items-center">
+          <Input
+            id="hfLocation"
+            className="flex-1"
+            type="text"
+            value={modelLocation}
+            onChange={e => setModelLocation(e.target.value)}
+          />
+          <Button
+            variant="secondary"
+            onClick={() => setModelLocation(BASE_MODEL)}
+          >
+            <RotateCcw className="h-4 w-4 mr-2" />
+            Reset to Default
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
   );
 }

--- a/client/src/components/transcribe/ChooseModel.tsx
+++ b/client/src/components/transcribe/ChooseModel.tsx
@@ -1,4 +1,18 @@
-import {useAtom} from 'jotai';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from 'components/ui/card';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from 'components/ui/select';
+import {useAtom, useSetAtom} from 'jotai';
 import urls from 'lib/urls';
 import Link from 'next/link';
 import React from 'react';
@@ -7,43 +21,54 @@ import {TrainingStatus} from 'types/Model';
 
 export default function ChooseModel() {
   const [models] = useAtom(modelsAtom);
-  const [modelLocation, setModelLocation] = useAtom(modelLocationAtom);
+  const setModelLocation = useSetAtom(modelLocationAtom);
 
   if (!models.some(model => model.status === TrainingStatus.Finished)) {
     return (
-      <div className="space-y-2">
-        <h2 className="text-lg font-light">Choose Trained Model</h2>
-        <p>
-          No trained models available! Before performing inference on an audio
-          file, you must create and train a model.
-        </p>
+      <Card>
+        <CardHeader>
+          <CardTitle>Select Trained Model</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <h2 className="text-lg font-light">Choose Trained Model</h2>
+          <p>
+            No trained models available! Before performing inference on an audio
+            file, you must create and train a model.
+          </p>
 
-        <Link href={urls.train.index}>
-          <button className="button">Models Home</button>
-        </Link>
-      </div>
+          <Link href={urls.train.index}>
+            <button className="button">Models Home</button>
+          </Link>
+        </CardContent>
+      </Card>
     );
   }
 
   return (
-    <div>
-      <h2 className="text-lg font-light">Select Trained Model</h2>
-      <p className="mt-2 text-sm text-gray-700 italic">
-        This only displays models which have finished training.
-      </p>
-      <div className="mt-4 flex space-x-4">
-        {models
-          .filter(model => model.status === TrainingStatus.Finished)
-          .map(model => (
-            <ModelSelector
-              key={model.modelName}
-              modelName={model.modelName}
-              isSelected={modelLocation === model.modelName}
-              onClick={() => setModelLocation(model.modelName)}
-            />
-          ))}
-      </div>
-    </div>
+    <Card>
+      <CardHeader>
+        <CardTitle>Select Trained Model</CardTitle>
+        <CardDescription>
+          This only displays the local models which have finished training.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Select onValueChange={setModelLocation}>
+          <SelectTrigger>
+            <SelectValue placeholder="Select a trained model." />
+          </SelectTrigger>
+          <SelectContent>
+            {models
+              .filter(model => model.status === TrainingStatus.Finished)
+              .map(model => (
+                <SelectItem key={model.modelName} value={model.modelName}>
+                  {model.modelName}
+                </SelectItem>
+              ))}
+          </SelectContent>
+        </Select>
+      </CardContent>
+    </Card>
   );
 }
 

--- a/client/src/components/transcribe/TranscriptionFileUpload.tsx
+++ b/client/src/components/transcribe/TranscriptionFileUpload.tsx
@@ -6,6 +6,14 @@ import {Check, X, Trash2} from 'react-feather';
 import {FileType, parseFileType} from 'lib/dataset';
 import colours from 'lib/colours';
 import {Button} from 'components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from 'components/ui/card';
+import DataTable, {Section} from 'components/DataTable';
 
 export default function TranscriptionFileUpload() {
   const [files, setFiles] = useAtom(transcriptionFilesAtom);
@@ -13,73 +21,73 @@ export default function TranscriptionFileUpload() {
   const removeUnsupported = () =>
     setFiles(files.filter(file => parseFileType(file.name) === FileType.Audio));
 
-  return (
-    <div className="section space-y-4">
-      <div>
-        <h2 className="subtitle">2. Upload Transcription Files</h2>
-        <p className="mt-2">Some description.</p>
-      </div>
+  const sections: Section<File>[] = [
+    {name: 'File Name', display: file => file.name},
+    {
+      name: 'Is Valid',
+      display: file =>
+        parseFileType(file.name) === FileType.Audio ? (
+          <Check color={colours.success} />
+        ) : (
+          <X color={colours.warning} />
+        ),
+    },
+    {
+      name: 'Delete',
+      display: (_, index) => (
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={() =>
+            setFiles(files.filter((_, _index) => index !== _index))
+          }
+        >
+          <Trash2 color={colours.delete} />
+        </Button>
+      ),
+    },
+  ];
 
-      <FileUpload callback={_files => setFiles([...files, ..._files])} />
-      {files.length > 0 && (
-        <>
-          <div className="space-y-4 mt-8">
-            <p className="font-bold">Uploaded files</p>
-            <table className="w-full table">
-              <thead>
-                <tr>
-                  <th>File Name</th>
-                  <th>Is Valid</th>
-                  <th>Delete</th>
-                </tr>
-              </thead>
-              <tbody>
-                {files.map((file, index) => (
-                  <tr key={index}>
-                    <td>{file.name}</td>
-                    <td>
-                      {parseFileType(file.name) === FileType.Audio ? (
-                        <Check color={colours.success} />
-                      ) : (
-                        <X color={colours.warning} />
-                      )}
-                    </td>
-                    <td>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={() =>
-                          setFiles(
-                            files.filter((_, _index) => index !== _index)
-                          )
-                        }
-                      >
-                        <Trash2 color={colours.delete} />
-                      </Button>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-          <div className="flex space-x-2 items-center justify-between">
-            <Button variant="secondary" onClick={() => setFiles([])}>
-              Reset
-            </Button>
-            <Button
-              variant="secondary"
-              onClick={removeUnsupported}
-              disabled={
-                files.filter(
-                  file => parseFileType(file.name) !== FileType.Audio
-                ).length === 0
-              }
-            >
-              Remove Unsupported Files
-            </Button>
-          </div>
-        </>
-      )}
-    </div>
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Upload Transcription Files</CardTitle>
+        <CardDescription>Some description.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <FileUpload callback={_files => setFiles([...files, ..._files])} />
+        {files.length > 0 && (
+          <>
+            <section className="space-y-4 mt-8">
+              <p className="font-bold">Uploaded files</p>
+              <div className="flex space-x-2 items-center">
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  onClick={() => setFiles([])}
+                >
+                  <Trash2 className="h-4 w-4 mr-2" />
+                  Delete All
+                </Button>
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  onClick={removeUnsupported}
+                  disabled={
+                    files.filter(
+                      file => parseFileType(file.name) !== FileType.Audio
+                    ).length === 0
+                  }
+                >
+                  <Trash2 className="h-4 w-4 mr-2" />
+                  Delete Unsupported Files
+                </Button>
+              </div>
+              <DataTable data={files} sections={sections} />
+            </section>
+          </>
+        )}
+      </CardContent>
+    </Card>
   );
 }

--- a/client/src/components/transcribe/TranscriptionsTable.tsx
+++ b/client/src/components/transcribe/TranscriptionsTable.tsx
@@ -17,12 +17,13 @@ import {
   Play,
   Trash2,
   Eye,
-} from 'react-feather';
+} from 'lucide-react';
 import {transcriptionsAtom} from 'store';
 import Transcription, {TranscriptionStatus} from 'types/Transcription';
 import DownloadTranscriptionFileButton from './DownloadTranscriptionFileButton';
 import Link from 'next/link';
 import {Button} from 'components/ui/button';
+import DataTable, {Section} from 'components/DataTable';
 
 const DatasetTable: React.FC = () => {
   const [transcriptions, setTranscriptions] = useAtom(transcriptionsAtom);
@@ -127,22 +128,73 @@ const DatasetTable: React.FC = () => {
     }
   };
 
+  const sections: Section<Transcription>[] = [
+    {name: 'Model Name', display: transcription => transcription.modelLocation},
+    {
+      name: 'Audio Name',
+      display: transcription => `${transcription.audioName}.wav`,
+    },
+    {
+      name: 'Text',
+      display: transcription => (
+        <DownloadTranscriptionFileButton
+          transcription={transcription}
+          fileType="text"
+        >
+          <Download />
+        </DownloadTranscriptionFileButton>
+      ),
+    },
+    {
+      name: 'Elan',
+      display: transcription => (
+        <DownloadTranscriptionFileButton
+          transcription={transcription}
+          fileType="elan"
+        >
+          <Download />
+        </DownloadTranscriptionFileButton>
+      ),
+    },
+    {
+      name: 'Status',
+      display: transcription => transcription.status,
+    },
+
+    {
+      name: 'Transcribe',
+      display: transcription => (
+        <button
+          onClick={() => _transcribe(transcription)}
+          disabled={transcription.status === TranscriptionStatus.Finished}
+        >
+          <TranscriptionStatusIndicator status={transcription.status} />
+        </button>
+      ),
+    },
+    {
+      name: 'View',
+      display: (_, index) => (
+        <Link href={`${urls.transcriptions.view}/${index}`}>
+          <a>
+            <Eye color={colours.info} />
+          </a>
+        </Link>
+      ),
+    },
+    {
+      name: 'Delete',
+      display: (_, index) => (
+        <button onClick={() => removeTranscription(index)}>
+          <Trash2 color={colours.delete} />
+        </button>
+      ),
+    },
+  ];
+
   return (
     <>
       <div className="mt-2 text-sm flex justify-between">
-        <Button
-          size="sm"
-          variant="outline"
-          disabled={
-            transcriptions.filter(
-              transcription =>
-                transcription.status === TranscriptionStatus.Finished
-            ).length === 0
-          }
-          onClick={downloadAllTranscriptions}
-        >
-          Download All Transcriptions
-        </Button>
         <div className="space-x-2">
           <Button
             size="sm"
@@ -155,79 +207,31 @@ const DatasetTable: React.FC = () => {
               ).length === 0
             }
           >
+            <Play className="h-4 w-4 mr-2" />
             Transcribe All
           </Button>
-          <Button size="sm" variant="outline" onClick={removeAll}>
-            Delete All
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={
+              transcriptions.filter(
+                transcription =>
+                  transcription.status === TranscriptionStatus.Finished
+              ).length === 0
+            }
+            onClick={downloadAllTranscriptions}
+          >
+            <Download className="h-4 w-4 mr-2" />
+            Download All
           </Button>
         </div>
+        <Button size="sm" variant="outline" onClick={removeAll}>
+          <Trash2 className="h-4 w-4 mr-2" />
+          Delete All
+        </Button>
       </div>
       <div className="text-left w-full">
-        <table className="w-full table">
-          <thead>
-            <tr>
-              <th>Model Name</th>
-              <th>Audio</th>
-              <th>Text</th>
-              <th>Elan</th>
-              <th>Status</th>
-              <th>Transcribe</th>
-              <th>View</th>
-              <th>Delete</th>
-            </tr>
-          </thead>
-          <tbody>
-            {transcriptions.map((transcription, index) => (
-              <tr key={index}>
-                <td>{transcription.modelLocation}</td>
-                <td>{transcription.audioName}.wav</td>
-
-                <td>
-                  <DownloadTranscriptionFileButton
-                    transcription={transcription}
-                    fileType="text"
-                  >
-                    <Download />
-                  </DownloadTranscriptionFileButton>
-                </td>
-                <td>
-                  <DownloadTranscriptionFileButton
-                    transcription={transcription}
-                    fileType="elan"
-                  >
-                    <Download />
-                  </DownloadTranscriptionFileButton>
-                </td>
-
-                <td>{transcription.status}</td>
-                <td>
-                  <button
-                    onClick={() => _transcribe(transcription)}
-                    disabled={
-                      transcription.status === TranscriptionStatus.Finished
-                    }
-                  >
-                    <TranscriptionStatusIndicator
-                      status={transcription.status}
-                    />
-                  </button>
-                </td>
-                <td>
-                  <Link href={`${urls.transcriptions.view}/${index}`}>
-                    <a>
-                      <Eye color={colours.info} />
-                    </a>
-                  </Link>
-                </td>
-                <td>
-                  <button onClick={() => removeTranscription(index)}>
-                    <Trash2 color={colours.delete} />
-                  </button>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        <DataTable data={transcriptions} sections={sections} />
       </div>
     </>
   );

--- a/client/src/components/transcribe/TranscriptionsTable.tsx
+++ b/client/src/components/transcribe/TranscriptionsTable.tsx
@@ -138,22 +138,20 @@ const DatasetTable: React.FC = () => {
       name: 'Text',
       display: transcription => (
         <DownloadTranscriptionFileButton
+          variant="icon"
           transcription={transcription}
           fileType="text"
-        >
-          <Download />
-        </DownloadTranscriptionFileButton>
+        />
       ),
     },
     {
       name: 'Elan',
       display: transcription => (
         <DownloadTranscriptionFileButton
+          variant="icon"
           transcription={transcription}
           fileType="elan"
-        >
-          <Download />
-        </DownloadTranscriptionFileButton>
+        />
       ),
     },
     {

--- a/client/src/components/ui/tabs.tsx
+++ b/client/src/components/ui/tabs.tsx
@@ -1,0 +1,53 @@
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "lib/utils"
+
+const Tabs = TabsPrimitive.Root
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex h-10 items-center justify-center rounded-md bg-slate-100 p-1 text-slate-500 dark:bg-slate-800 dark:text-slate-400",
+      className
+    )}
+    {...props}
+  />
+))
+TabsList.displayName = TabsPrimitive.List.displayName
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-white transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-white data-[state=active]:text-slate-950 data-[state=active]:shadow-sm dark:ring-offset-slate-950 dark:focus-visible:ring-slate-800 dark:data-[state=active]:bg-slate-950 dark:data-[state=active]:text-slate-50",
+      className
+    )}
+    {...props}
+  />
+))
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "mt-2 ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2 dark:ring-offset-slate-950 dark:focus-visible:ring-slate-800",
+      className
+    )}
+    {...props}
+  />
+))
+TabsContent.displayName = TabsPrimitive.Content.displayName
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/client/src/pages/datasets.tsx
+++ b/client/src/pages/datasets.tsx
@@ -30,10 +30,9 @@ const DatasetsPage: NextPage = () => {
   return (
     <div className="container">
       <h1 className="title">Datasets</h1>
-      <p className="mt-2 page-description">Blah blah blah</p>
 
-      <ClientOnly className="mt-8 space-y-4">
-        <div className="space-x-2 mt-2 flex justify-between">
+      <ClientOnly className="mt-4">
+        <div className="space-x-2 mb-8 flex justify-between">
           <Link href={urls.datasets.new}>
             <a>
               <Button>
@@ -53,8 +52,10 @@ const DatasetsPage: NextPage = () => {
             </Link>
           )}
         </div>
-        <p className="subtitle">Your Datasets</p>
-        <DatasetTable />
+        <section className="space-y-4">
+          <h2 className="subtitle">Your Datasets</h2>
+          <DatasetTable />
+        </section>
       </ClientOnly>
     </div>
   );

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -6,8 +6,6 @@ const Home: NextPage = () => {
   return (
     <div className="container">
       <h1 className="text-center title">ELPIS</h1>
-      <p className="page-description text-center mt-2">Blah blah blah</p>
-
       <div className="mt-12">
         <p className="subtitle text-center">Choose a Task</p>
         <div className="flex space-x-2 items-center justify-center mt-4">

--- a/client/src/pages/train.tsx
+++ b/client/src/pages/train.tsx
@@ -32,10 +32,9 @@ const TrainPage: NextPage = () => {
       <div className="flex space-x-8">
         <div className="w-full">
           <h1 className="title">Train Models</h1>
-          <p className="mt-2 page-description">Blah blah blah</p>
 
-          <ClientOnly className="mt-8 space-y-4">
-            <div className="flex items-center justify-between">
+          <ClientOnly className="mt-4 space-y-4">
+            <div className="mb-8 flex items-center justify-between">
               <div className="space-x-2 flex items-center">
                 <Link href={urls.train.new}>
                   <a>
@@ -69,8 +68,10 @@ const TrainPage: NextPage = () => {
                 </div>
               )}
             </div>
-            <h2 className="subtitle mt-8 mb-2">Your Models</h2>
-            <ModelTable />
+            <section className="space-y-4">
+              <h2 className="subtitle mt-8 mb-2">Your Models</h2>
+              <ModelTable />
+            </section>
           </ClientOnly>
         </div>
       </div>

--- a/client/src/pages/transcriptions.tsx
+++ b/client/src/pages/transcriptions.tsx
@@ -8,6 +8,7 @@ import urls from 'lib/urls';
 import Transcription from 'types/Transcription';
 import ClientOnly from 'components/ClientOnly';
 import {Button} from 'components/ui/button';
+import {Plus} from 'lucide-react';
 
 export default function TranscriptionsPage() {
   const [, setTranscriptions] = useAtom(transcriptionsAtom);
@@ -28,19 +29,21 @@ export default function TranscriptionsPage() {
   return (
     <div className="container">
       <h1 className="title">Transcriptions</h1>
-      <p className="mt-2 page-description">Blah blah blah</p>
+      <div className="mt-4">
+        <Link href={urls.transcriptions.new}>
+          <a>
+            <Button>
+              <Plus className="h-4 w-4 mr-2" />
+              Create New
+            </Button>
+          </a>
+        </Link>
+      </div>
 
       <ClientOnly className="mt-8 space-y-4">
         <h2 className="subtitle">Your Transcriptions</h2>
         <TranscriptionsTable />
       </ClientOnly>
-      <div className="mt-4">
-        <Link href={urls.transcriptions.new}>
-          <a>
-            <Button>Create New</Button>
-          </a>
-        </Link>
-      </div>
     </div>
   );
 }

--- a/client/src/pages/transcriptions/new.tsx
+++ b/client/src/pages/transcriptions/new.tsx
@@ -14,14 +14,18 @@ import {useRouter} from 'next/router';
 import urls from 'lib/urls';
 import {FileType, parseFileType} from 'lib/dataset';
 import {Button} from 'components/ui/button';
+import {Tabs, TabsContent, TabsList, TabsTrigger} from 'components/ui/tabs';
+import ClientOnly from 'components/ClientOnly';
+
+type ModelType = 'local' | 'huggingface';
 
 export default function TranscribePage() {
   const router = useRouter();
   const [files, setFiles] = useAtom(transcriptionFilesAtom);
   const [modelLocation, setModelLocation] = useAtom(modelLocationAtom);
   const [models] = useAtom(modelsAtom);
-  const [isLocal, setIsLocal] = useAtom(modelIsLocalAtom);
   const [error, setError] = useState('');
+  const [type, setType] = useState<ModelType>('local');
 
   const _createTranscriptions = async () => {
     const response = await createTranscriptionJobs(files, modelLocation);
@@ -40,30 +44,34 @@ export default function TranscribePage() {
     files.length > 0 &&
     files.every(file => parseFileType(file.name) === FileType.Audio) &&
     modelLocation.length > 0 &&
-    (!isLocal || models.map(model => model.modelName).includes(modelLocation));
+    (type === 'huggingface' ||
+      models.map(model => model.modelName).includes(modelLocation));
 
   return (
     <div className="container flex flex-col space-y-4">
       <div>
         <h1 className="title">New Transcriptions</h1>
-        <p className="page-description mt-2">blah</p>
       </div>
 
-      <div className="section space-y-4">
-        <h2 className="subtitle">1. Choose model location</h2>
-        <div className="mt-4 flex space-x-2 items-center">
-          <input
-            type={'checkbox'}
-            id="isLocal"
-            checked={isLocal}
-            onChange={() => setIsLocal(!isLocal)}
-          />
-          <label htmlFor="isLocal" className="text-sm">
-            Use Local Model?
-          </label>
-        </div>
-        {isLocal ? <ChooseModel /> : <ChooseHuggingFaceModel />}
-      </div>
+      <ClientOnly>
+        <Tabs
+          className="w-full"
+          value={type}
+          onValueChange={x => setType(x as ModelType)}
+        >
+          <TabsList className="grid grid-cols-2 w-full">
+            <TabsTrigger value="local">Local Model</TabsTrigger>
+            <TabsTrigger value="huggingface">Huggingface Model</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="local">
+            <ChooseModel />
+          </TabsContent>
+          <TabsContent value="huggingface">
+            <ChooseHuggingFaceModel />
+          </TabsContent>
+        </Tabs>
+      </ClientOnly>
 
       <TranscriptionFileUpload />
 

--- a/client/src/pages/transcriptions/view/[index].tsx
+++ b/client/src/pages/transcriptions/view/[index].tsx
@@ -4,10 +4,20 @@ import {getText} from 'lib/api/transcribe';
 import urls from 'lib/urls';
 import Link from 'next/link';
 import {useRouter} from 'next/router';
-import React, {useEffect, useState} from 'react';
-import {Download} from 'react-feather';
+import React, {FC, useEffect, useState} from 'react';
+import {Dot, Download, FileAudio2, FileBox, Home, Icon} from 'lucide-react';
 import {transcriptionsAtom} from 'store';
 import Transcription, {TranscriptionStatus} from 'types/Transcription';
+import {Button} from 'components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from 'components/ui/card';
+import {Label} from 'components/ui/label';
+import {Edit2, ExternalLink} from 'lucide-react';
 
 export default function ViewTranscriptionPage() {
   const [transcriptions] = useAtom(transcriptionsAtom);
@@ -65,56 +75,85 @@ export default function ViewTranscriptionPage() {
         <h1 className="title">Transcription</h1>
         <Link href={urls.transcriptions.index}>
           <a>
-            <button className="button">Back</button>
+            <Button variant="secondary">Back</Button>
           </a>
         </Link>
       </div>
-      <div className="grid grid-cols-2 section">
-        <p className="font-semibold">Model Name:</p>
-        <p>
-          {transcription.isLocal ? (
-            transcription.modelLocation
-          ) : (
-            <a
-              className="text-blue-500"
-              href={`https://huggingface.co/${transcription.modelLocation}`}
-            >
-              {transcription.modelLocation}
-            </a>
-          )}
-        </p>
 
-        <p className="font-semibold">Audio Name:</p>
-        <p>{transcription.audioName}.wav</p>
-        <p className="font-semibold">Is Local:</p>
-        <p>{transcription.isLocal ? 'True' : 'False'}</p>
-        <p className="font-semibold">Status:</p>
-        <p>{transcription.status}</p>
-      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle>Info</CardTitle>
+        </CardHeader>
+        <CardContent className="grid grid-cols-2 gap-4 font-light text-base">
+          <InfoSection name="Audio Name" icon={FileAudio2}>
+            <p>{transcription.audioName}.wav</p>
+          </InfoSection>
+          <InfoSection name="Model Name" icon={FileBox}>
+            <p>
+              {transcription.isLocal ? (
+                transcription.modelLocation
+              ) : (
+                <a
+                  className="text-blue-500"
+                  href={`https://huggingface.co/${transcription.modelLocation}`}
+                >
+                  {transcription.modelLocation}
+                </a>
+              )}
+            </p>
+          </InfoSection>
+          <InfoSection name="Is Local" icon={Home}>
+            <p>{transcription.isLocal ? 'True' : 'False'}</p>
+          </InfoSection>
+          <InfoSection name="Status" icon={Dot}>
+            <p>{transcription.status}</p>
+          </InfoSection>
+        </CardContent>
+      </Card>
       {transcription.status === TranscriptionStatus.Finished && (
-        <>
-          <div className="section">
-            <h2 className="font-semibold mb-2">Transcript:</h2>
-            <p className="text-gray-700">{text}</p>
-          </div>
-          <div className="flex space-x-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>Transcript</CardTitle>
+          </CardHeader>
+          <CardContent>{text}</CardContent>
+          <CardFooter className="flex space-x-2">
             <DownloadTranscriptionFileButton
               transcription={transcription}
               fileType="text"
-              className="button"
             >
-              Download Text
+              <Download className="h-4 w-4 mr-2" />
+              <span>Download Text</span>
             </DownloadTranscriptionFileButton>
             <DownloadTranscriptionFileButton
               transcription={transcription}
               fileType="elan"
-              className="button"
             >
-              Download Elan
+              <Download className="h-4 w-4 mr-2" />
+              <span>Download Elan</span>
             </DownloadTranscriptionFileButton>
-          </div>
-        </>
+          </CardFooter>
+        </Card>
       )}
     </div>
   );
 }
+
+type InfoSectionProps = {
+  name: string;
+  icon: Icon;
+  children: React.ReactNode;
+};
+
+const InfoSection: FC<InfoSectionProps> = ({name, icon, children}) => {
+  const SectionIcon = icon;
+
+  return (
+    <div className="flex items-center space-x-2">
+      <SectionIcon className="h-8 w-8" strokeWidth={1} />
+      <div>
+        <Label>{name}</Label>
+        <div className="text-sm">{children}</div>
+      </div>
+    </div>
+  );
+};

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -356,6 +356,15 @@
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-primitive" "1.0.3"
 
+"@radix-ui/react-presence@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-1.0.1.tgz#491990ba913b8e2a5db1b06b203cb24b5cdef9ba"
+  integrity sha512-UXLW4UAbIY5ZjcvzjfRFo5gxva8QirC9hF7wRE4U5gz+TP0DbRk+//qyuAQ1McDxBt1xNMBTaciFGvEmJvAZCg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-use-layout-effect" "1.0.1"
+
 "@radix-ui/react-primitive@1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-1.0.3.tgz#d49ea0f3f0b2fe3ab1cb5667eb03e8b843b914d0"
@@ -363,6 +372,22 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-slot" "1.0.2"
+
+"@radix-ui/react-roving-focus@1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-roving-focus/-/react-roving-focus-1.0.4.tgz#e90c4a6a5f6ac09d3b8c1f5b5e81aab2f0db1974"
+  integrity sha512-2mUg5Mgcu001VkGy+FfzZyzbmuUWzgWkj3rvv4yu+mLw03+mTzbxZHvfcGyFp2b8EkQeMkpRQ5FiA2Vr2O6TeQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-collection" "1.0.3"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-direction" "1.0.1"
+    "@radix-ui/react-id" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
 
 "@radix-ui/react-select@^1.2.2":
   version "1.2.2"
@@ -413,6 +438,21 @@
     "@radix-ui/react-use-controllable-state" "1.0.1"
     "@radix-ui/react-use-previous" "1.0.1"
     "@radix-ui/react-use-size" "1.0.1"
+
+"@radix-ui/react-tabs@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-tabs/-/react-tabs-1.0.4.tgz#993608eec55a5d1deddd446fa9978d2bc1053da2"
+  integrity sha512-egZfYY/+wRNCflXNHx+dePvnz9FbmssDTJBtgRfDY7e8SE5oIo3Py2eCB1ckAbh1Q7cQ/6yJZThJ++sgbxibog==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-direction" "1.0.1"
+    "@radix-ui/react-id" "1.0.1"
+    "@radix-ui/react-presence" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-roving-focus" "1.0.4"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
 
 "@radix-ui/react-use-callback-ref@1.0.1":
   version "1.0.1"


### PR DESCRIPTION
- Updated transcription flow with the new UI components.
- Added `Tabs` ui components from ui library.
- Removed the 'Blah blah blah' descriptions from all main pages. 

Some screenshots:
Transcription Table
<img width="1161" alt="Screenshot 2023-07-18 at 11 47 15 am" src="https://github.com/CoEDL/elpis_next/assets/24891460/b452533b-aa84-4cb1-a046-b09dea169105">

New Transcription page
<img width="794" alt="Screenshot 2023-07-18 at 11 47 46 am" src="https://github.com/CoEDL/elpis_next/assets/24891460/da7a05e9-be69-48cb-873d-257697df10db">

View Transcriptions page
<img width="765" alt="Screenshot 2023-07-18 at 11 48 22 am" src="https://github.com/CoEDL/elpis_next/assets/24891460/4d49d681-a907-496a-bb4e-e4893f2fb95b">
