### PR TITLE
Add confirmation dialogue to deletions.

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.1.1",
+    "@radix-ui/react-alert-dialog": "^1.0.4",
     "@radix-ui/react-label": "^2.0.2",
     "@radix-ui/react-select": "^1.2.2",
     "@radix-ui/react-slot": "^1.0.2",

--- a/client/src/components/ConfirmDelete.tsx
+++ b/client/src/components/ConfirmDelete.tsx
@@ -1,0 +1,44 @@
+import React, {FC} from 'react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from './ui/alert-dialog';
+
+type ConfirmDeleteProps = {
+  title: string;
+  children: React.ReactNode;
+  description?: string;
+  action: () => void;
+};
+
+const ConfirmDelete: FC<ConfirmDeleteProps> = ({
+  children,
+  title,
+  description,
+  action,
+}) => {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>{children}</AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={action}>Delete</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};
+
+export default ConfirmDelete;

--- a/client/src/components/DownloadFileButton.tsx
+++ b/client/src/components/DownloadFileButton.tsx
@@ -1,0 +1,67 @@
+import clsx from 'clsx';
+import fileDownload from 'js-file-download';
+import {Download, Loader} from 'lucide-react';
+import React, {FC, useState} from 'react';
+import {Button, ButtonProps} from './ui/button';
+
+export type DownloadFileButtonProps = {
+  downloadFile: () => Promise<Response>;
+  filename: string;
+  text?: string;
+  loadingText?: string;
+  errorText?: string;
+};
+
+const DEFAULT_ERROR_TEXT = 'Error downloading files';
+
+const DownloadFileButton: FC<DownloadFileButtonProps & ButtonProps> = ({
+  downloadFile,
+  text,
+  filename,
+  loadingText,
+  errorText,
+  disabled = false,
+  ...rest
+}) => {
+  const [downloading, setDownloading] = useState<boolean>(false);
+
+  const download = async () => {
+    if (downloading) return;
+    setDownloading(true);
+
+    const response = await downloadFile();
+    if (response.ok) {
+      const blob = await response.blob();
+      fileDownload(blob, filename);
+    } else {
+      console.error(errorText ?? DEFAULT_ERROR_TEXT);
+    }
+
+    setDownloading(false);
+  };
+
+  const Icon = downloading ? Loader : Download;
+
+  const hasText = text !== undefined && text.length > 0;
+  if (hasText) {
+    return (
+      <Button {...rest} onClick={download} disabled={disabled || downloading}>
+        <Icon className={clsx('h-4 w-4 mr-2', {'animate-spin': downloading})} />
+        {downloading ? loadingText ?? text : text}
+      </Button>
+    );
+  }
+
+  return (
+    <button {...rest} onClick={download} disabled={disabled || downloading}>
+      <Icon
+        className={clsx({
+          'animate-spin': downloading,
+          'text-gray-300': disabled,
+        })}
+      />
+    </button>
+  );
+};
+
+export default DownloadFileButton;

--- a/client/src/components/train/DatasetTable.tsx
+++ b/client/src/components/train/DatasetTable.tsx
@@ -1,14 +1,13 @@
 import {useAtom} from 'jotai';
-import fileDownload from 'js-file-download';
 import {deleteDataset, downloadDataset} from 'lib/api/datasets';
 import React from 'react';
-import {Download, Trash2} from 'lucide-react';
+import {Trash2} from 'lucide-react';
 import {datasetsAtom} from 'store';
 import DataTable, {Section} from 'components/DataTable';
 import Dataset from 'types/Dataset';
-import {Button} from 'components/ui/button';
 import ConfirmDelete from 'components/ConfirmDelete';
 import colours from 'lib/colours';
+import DownloadFileButton from 'components/DownloadFileButton';
 
 const DatasetTable: React.FC = () => {
   const [datasets, setDatasets] = useAtom(datasetsAtom);
@@ -23,16 +22,6 @@ const DatasetTable: React.FC = () => {
     }
   };
 
-  const _downloadDataset = async (datasetName: string) => {
-    const response = await downloadDataset(datasetName);
-    if (response.ok) {
-      const blob = await response.blob();
-      fileDownload(blob, datasetName + '.zip');
-    } else {
-      console.error("Couldn't download dataset :(");
-    }
-  };
-
   const sections: Section<Dataset>[] = [
     {
       name: 'Name',
@@ -43,13 +32,10 @@ const DatasetTable: React.FC = () => {
     {
       name: 'Download',
       display: dataset => (
-        <Button
-          size="icon"
-          variant="ghost"
-          onClick={() => _downloadDataset(dataset.name)}
-        >
-          <Download />
-        </Button>
+        <DownloadFileButton
+          downloadFile={() => downloadDataset(dataset.name)}
+          filename={`${dataset.name}.zip`}
+        />
       ),
     },
     {

--- a/client/src/components/train/DatasetTable.tsx
+++ b/client/src/components/train/DatasetTable.tsx
@@ -7,6 +7,8 @@ import {datasetsAtom} from 'store';
 import DataTable, {Section} from 'components/DataTable';
 import Dataset from 'types/Dataset';
 import {Button} from 'components/ui/button';
+import ConfirmDelete from 'components/ConfirmDelete';
+import colours from 'lib/colours';
 
 const DatasetTable: React.FC = () => {
   const [datasets, setDatasets] = useAtom(datasetsAtom);
@@ -53,13 +55,15 @@ const DatasetTable: React.FC = () => {
     {
       name: 'Delete',
       display: dataset => (
-        <Button
-          size="icon"
-          variant="ghost"
-          onClick={() => _deleteDataset(dataset.name)}
+        <ConfirmDelete
+          title={`Delete ${dataset.name}?`}
+          description="Once deleted, the local dataset cannot be recovered."
+          action={() => _deleteDataset(dataset.name)}
         >
-          <Trash2 />
-        </Button>
+          <button title="Delete this dataset">
+            <Trash2 color={colours.delete} />
+          </button>
+        </ConfirmDelete>
       ),
     },
   ];

--- a/client/src/components/train/ModelTable.tsx
+++ b/client/src/components/train/ModelTable.tsx
@@ -11,6 +11,7 @@ import Model, {TrainingStatus} from 'types/Model';
 import TrainingStatusIndicator from 'components/train/TrainingStatusIndicator';
 import DataTable, {Section} from 'components/DataTable';
 import ConfirmDelete from 'components/ConfirmDelete';
+import DownloadFileButton from 'components/DownloadFileButton';
 
 const ModelTable: React.FC = () => {
   const [models, setModels] = useAtom(modelsAtom);
@@ -33,16 +34,6 @@ const ModelTable: React.FC = () => {
       nextModel,
       ...models.slice(index + 1),
     ]);
-  };
-
-  const download = async (modelName: string) => {
-    const response = await downloadModel(modelName);
-    if (response.ok) {
-      const blob = await response.blob();
-      fileDownload(blob, modelName + '.zip');
-    } else {
-      console.error("Couldn't download model :(");
-    }
   };
 
   const _trainModel = async (index: number) => {
@@ -93,18 +84,12 @@ const ModelTable: React.FC = () => {
     {
       name: 'Download',
       display: model => (
-        <button
-          onClick={() => download(model.modelName)}
+        <DownloadFileButton
+          filename={`${model.modelName}.zip`}
+          errorText={"Couldn't download model :("}
+          downloadFile={() => downloadModel(model.modelName)}
           disabled={model.status !== TrainingStatus.Finished}
-        >
-          <Download
-            color={
-              model.status === TrainingStatus.Finished
-                ? colours.grey
-                : colours.unavailable
-            }
-          />
-        </button>
+        />
       ),
     },
     {

--- a/client/src/components/train/ModelTable.tsx
+++ b/client/src/components/train/ModelTable.tsx
@@ -10,6 +10,7 @@ import {modelsAtom} from 'store';
 import Model, {TrainingStatus} from 'types/Model';
 import TrainingStatusIndicator from 'components/train/TrainingStatusIndicator';
 import DataTable, {Section} from 'components/DataTable';
+import ConfirmDelete from 'components/ConfirmDelete';
 
 const ModelTable: React.FC = () => {
   const [models, setModels] = useAtom(modelsAtom);
@@ -119,9 +120,15 @@ const ModelTable: React.FC = () => {
     {
       name: 'Delete',
       display: model => (
-        <button onClick={() => _deleteModel(model.modelName)}>
-          <Trash2 color={colours.delete} />
-        </button>
+        <ConfirmDelete
+          title={`Delete ${model.modelName}?`}
+          description="Once deleted, the model cannot be recovered."
+          action={() => _deleteModel(model.modelName)}
+        >
+          <button>
+            <Trash2 color={colours.delete} />
+          </button>
+        </ConfirmDelete>
       ),
     },
   ];

--- a/client/src/components/transcribe/DownloadTranscriptionFileButton.tsx
+++ b/client/src/components/transcribe/DownloadTranscriptionFileButton.tsx
@@ -1,64 +1,37 @@
 import {getElan, getText} from 'lib/api/transcribe';
-import fileDownload from 'js-file-download';
-import React, {useState} from 'react';
-import Transcription from 'types/Transcription';
-import {Button} from 'components/ui/button';
-import {Download, Loader} from 'lucide-react';
-import clsx from 'clsx';
+import React from 'react';
+import Transcription, {TranscriptionStatus} from 'types/Transcription';
+import DownloadFileButton from 'components/DownloadFileButton';
+import {ButtonProps} from 'components/ui/button';
 
 type Props = {
-  variant?: 'full' | 'icon';
+  isIcon?: boolean;
   fileType: 'elan' | 'text';
   transcription: Transcription;
 };
 
-const DownloadTranscriptionFileButton: React.FC<
-  Props & React.HTMLAttributes<HTMLButtonElement>
-> = ({fileType, variant = 'full', transcription, ...other}) => {
-  const request = fileType === 'elan' ? getElan : getText;
+const DownloadTranscriptionFileButton: React.FC<Props & ButtonProps> = ({
+  fileType,
+  transcription,
+  isIcon = false,
+  ...rest
+}) => {
   const suffix = fileType === 'elan' ? '.eaf' : '.txt';
   const fileName = transcription.audioName + suffix;
+
+  const request = fileType === 'elan' ? getElan : getText;
   const text = fileType === 'elan' ? 'Download Elan' : 'Download Text';
-  const [downloading, setDownloading] = useState(false);
-
-  const downloadFile = async () => {
-    if (downloading) return;
-    setDownloading(true);
-    const response = await request(
-      transcription.modelLocation,
-      transcription.audioName
-    );
-    if (response.ok) {
-      const blob = await response.blob();
-      fileDownload(blob, fileName);
-    }
-    setDownloading(false);
-  };
-
-  if (transcription.status !== 'finished') {
-    return null;
-  }
-
-  const Icon = downloading ? Loader : Download;
-
-  if (variant === 'icon') {
-    return (
-      <button {...other} onClick={downloadFile} disabled={downloading}>
-        <Icon className={clsx({'animate-spin': downloading})} />
-      </button>
-    );
-  }
 
   return (
-    <Button
-      variant="secondary"
-      {...other}
-      onClick={downloadFile}
-      disabled={downloading}
-    >
-      <Icon className={clsx('h-4 w-4 mr-2', {'animate-spin': downloading})} />
-      {text}
-    </Button>
+    <DownloadFileButton
+      downloadFile={() =>
+        request(transcription.modelLocation, transcription.audioName)
+      }
+      text={isIcon ? undefined : text}
+      filename={fileName}
+      disabled={transcription.status !== TranscriptionStatus.Finished}
+      {...rest}
+    />
   );
 };
 

--- a/client/src/components/transcribe/DownloadTranscriptionFileButton.tsx
+++ b/client/src/components/transcribe/DownloadTranscriptionFileButton.tsx
@@ -3,7 +3,8 @@ import fileDownload from 'js-file-download';
 import React, {useState} from 'react';
 import Transcription from 'types/Transcription';
 import {Button} from 'components/ui/button';
-import {Download} from 'lucide-react';
+import {Download, Loader} from 'lucide-react';
+import clsx from 'clsx';
 
 type Props = {
   variant?: 'full' | 'icon';
@@ -18,7 +19,6 @@ const DownloadTranscriptionFileButton: React.FC<
   const suffix = fileType === 'elan' ? '.eaf' : '.txt';
   const fileName = transcription.audioName + suffix;
   const text = fileType === 'elan' ? 'Download Elan' : 'Download Text';
-
   const [downloading, setDownloading] = useState(false);
 
   const downloadFile = async () => {
@@ -28,28 +28,35 @@ const DownloadTranscriptionFileButton: React.FC<
       transcription.modelLocation,
       transcription.audioName
     );
-    setDownloading(false);
     if (response.ok) {
       const blob = await response.blob();
       fileDownload(blob, fileName);
     }
+    setDownloading(false);
   };
 
   if (transcription.status !== 'finished') {
     return null;
   }
 
+  const Icon = downloading ? Loader : Download;
+
   if (variant === 'icon') {
     return (
       <button {...other} onClick={downloadFile} disabled={downloading}>
-        <Download />
+        <Icon className={clsx({'animate-spin': downloading})} />
       </button>
     );
   }
 
   return (
-    <Button variant="secondary" {...other} onClick={downloadFile}>
-      <Download className="h-4 w-4 mr-2" />
+    <Button
+      variant="secondary"
+      {...other}
+      onClick={downloadFile}
+      disabled={downloading}
+    >
+      <Icon className={clsx('h-4 w-4 mr-2', {'animate-spin': downloading})} />
       {text}
     </Button>
   );

--- a/client/src/components/transcribe/TranscriptionsTable.tsx
+++ b/client/src/components/transcribe/TranscriptionsTable.tsx
@@ -1,5 +1,4 @@
 import {useAtom} from 'jotai';
-import fileDownload from 'js-file-download';
 import urls from 'lib/urls';
 import {
   deleteTranscription,
@@ -8,16 +7,8 @@ import {
   transcribe,
 } from 'lib/api/transcribe';
 import colours from 'lib/colours';
-import React, {useState} from 'react';
-import {
-  AlertCircle,
-  Download,
-  Check,
-  Loader,
-  Play,
-  Trash2,
-  Eye,
-} from 'lucide-react';
+import React from 'react';
+import {AlertCircle, Check, Loader, Play, Trash2, Eye} from 'lucide-react';
 import {transcriptionsAtom} from 'store';
 import Transcription, {TranscriptionStatus} from 'types/Transcription';
 import DownloadTranscriptionFileButton from './DownloadTranscriptionFileButton';
@@ -25,10 +16,12 @@ import Link from 'next/link';
 import {Button} from 'components/ui/button';
 import DataTable, {Section} from 'components/DataTable';
 import ConfirmDelete from 'components/ConfirmDelete';
+import DownloadFileButton from 'components/DownloadFileButton';
+
+const TRANSCRIPTION_FILES_FILENAME = 'transcription_files.zip';
 
 const DatasetTable: React.FC = () => {
   const [transcriptions, setTranscriptions] = useAtom(transcriptionsAtom);
-  const [downloading, setDownloading] = useState(false);
 
   if (transcriptions.length === 0) {
     return <p>No current transcriptions!</p>;
@@ -124,19 +117,6 @@ const DatasetTable: React.FC = () => {
     }
   };
 
-  const downloadAllTranscriptions = async () => {
-    if (downloading) return;
-    setDownloading(true);
-    const response = await downloadFiles();
-    if (response.ok) {
-      const blob = await response.blob();
-      fileDownload(blob, 'transcription_files.zip');
-    } else {
-      console.error('Error downloading transcription files');
-    }
-    setDownloading(false);
-  };
-
   const sections: Section<Transcription>[] = [
     {name: 'Model Name', display: transcription => transcription.modelLocation},
     {
@@ -147,7 +127,7 @@ const DatasetTable: React.FC = () => {
       name: 'Text',
       display: transcription => (
         <DownloadTranscriptionFileButton
-          variant="icon"
+          isIcon
           transcription={transcription}
           fileType="text"
         />
@@ -157,7 +137,7 @@ const DatasetTable: React.FC = () => {
       name: 'Elan',
       display: transcription => (
         <DownloadTranscriptionFileButton
-          variant="icon"
+          isIcon
           transcription={transcription}
           fileType="elan"
         />
@@ -228,25 +208,19 @@ const DatasetTable: React.FC = () => {
             )}
             Transcribe All
           </Button>
-          <Button
+          <DownloadFileButton
+            filename={TRANSCRIPTION_FILES_FILENAME}
+            downloadFile={downloadFiles}
+            text="Download All"
             size="sm"
             variant="outline"
             disabled={
-              downloading ||
               transcriptions.filter(
                 transcription =>
                   transcription.status === TranscriptionStatus.Finished
               ).length === 0
             }
-            onClick={downloadAllTranscriptions}
-          >
-            {downloading ? (
-              <Loader className="h-4 w-4 mr-2 animate-spin" />
-            ) : (
-              <Download className="h-4 w-4 mr-2" />
-            )}
-            Download All
-          </Button>
+          />
         </div>
         <ConfirmDelete
           title="Delete all Transcriptions?"

--- a/client/src/components/transcribe/TranscriptionsTable.tsx
+++ b/client/src/components/transcribe/TranscriptionsTable.tsx
@@ -230,10 +230,16 @@ const DatasetTable: React.FC = () => {
             Download All
           </Button>
         </div>
-        <Button size="sm" variant="outline" onClick={removeAll}>
-          <Trash2 className="h-4 w-4 mr-2" />
-          Delete All
-        </Button>
+        <ConfirmDelete
+          title="Delete all Transcriptions?"
+          description="Once deleted, these transcriptions will not be recoverable."
+          action={removeAll}
+        >
+          <Button size="sm" variant="outline">
+            <Trash2 className="h-4 w-4 mr-2" />
+            Delete All
+          </Button>
+        </ConfirmDelete>
       </div>
       <div className="text-left w-full">
         <DataTable data={transcriptions} sections={sections} />

--- a/client/src/components/transcribe/TranscriptionsTable.tsx
+++ b/client/src/components/transcribe/TranscriptionsTable.tsx
@@ -24,6 +24,7 @@ import DownloadTranscriptionFileButton from './DownloadTranscriptionFileButton';
 import Link from 'next/link';
 import {Button} from 'components/ui/button';
 import DataTable, {Section} from 'components/DataTable';
+import ConfirmDelete from 'components/ConfirmDelete';
 
 const DatasetTable: React.FC = () => {
   const [transcriptions, setTranscriptions] = useAtom(transcriptionsAtom);
@@ -182,10 +183,16 @@ const DatasetTable: React.FC = () => {
     },
     {
       name: 'Delete',
-      display: (_, index) => (
-        <button onClick={() => removeTranscription(index)}>
-          <Trash2 color={colours.delete} />
-        </button>
+      display: (transcription, index) => (
+        <ConfirmDelete
+          title="Delete transcription?"
+          description={`Once deleted, the transcription for ${transcription.audioName}.wav will not be recoverable.`}
+          action={() => removeTranscription(index)}
+        >
+          <button>
+            <Trash2 color={colours.delete} />
+          </button>
+        </ConfirmDelete>
       ),
     },
   ];

--- a/client/src/components/ui/alert-dialog.tsx
+++ b/client/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,143 @@
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+
+import { cn } from "lib/utils"
+import { buttonVariants } from "components/ui/button"
+
+const AlertDialog = AlertDialogPrimitive.Root
+
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger
+
+const AlertDialogPortal = ({
+  className,
+  ...props
+}: AlertDialogPrimitive.AlertDialogPortalProps) => (
+  <AlertDialogPrimitive.Portal className={cn(className)} {...props} />
+)
+AlertDialogPortal.displayName = AlertDialogPrimitive.Portal.displayName
+
+const AlertDialogOverlay = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, children, ...props }, ref) => (
+  <AlertDialogPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-white/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 dark:bg-slate-950/80",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName
+
+const AlertDialogContent = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-slate-200 bg-white p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg md:w-full dark:border-slate-800 dark:bg-slate-950",
+        className
+      )}
+      {...props}
+    />
+  </AlertDialogPortal>
+))
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName
+
+const AlertDialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+AlertDialogHeader.displayName = "AlertDialogHeader"
+
+const AlertDialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+AlertDialogFooter.displayName = "AlertDialogFooter"
+
+const AlertDialogTitle = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold", className)}
+    {...props}
+  />
+))
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName
+
+const AlertDialogDescription = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-slate-500 dark:text-slate-400", className)}
+    {...props}
+  />
+))
+AlertDialogDescription.displayName =
+  AlertDialogPrimitive.Description.displayName
+
+const AlertDialogAction = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Action
+    ref={ref}
+    className={cn(buttonVariants(), className)}
+    {...props}
+  />
+))
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName
+
+const AlertDialogCancel = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Cancel
+    ref={ref}
+    className={cn(
+      buttonVariants({ variant: "outline" }),
+      "mt-2 sm:mt-0",
+      className
+    )}
+    {...props}
+  />
+))
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName
+
+export {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}

--- a/client/src/pages/datasets/new.tsx
+++ b/client/src/pages/datasets/new.tsx
@@ -16,6 +16,7 @@ import {useRouter} from 'next/router';
 import urls from 'lib/urls';
 import {isValidForDataset} from 'lib/dataset';
 import {Button} from 'components/ui/button';
+import {Loader} from 'lucide-react';
 
 const NewDatasetPage: React.FC = () => {
   const router = useRouter();
@@ -25,6 +26,7 @@ const NewDatasetPage: React.FC = () => {
   const [cleaningOptions] = useAtom(cleaningOptionsAtom);
   const [elanOptions] = useAtom(elanOptionsAtom);
   const [name] = useAtom(datasetNameAtom);
+  const [saving, setSaving] = useState(false);
 
   const resetFiles = useResetAtom(filesAtom);
   const resetElanOptions = useResetAtom(elanOptionsAtom);
@@ -43,7 +45,8 @@ const NewDatasetPage: React.FC = () => {
   };
 
   const save = async () => {
-    if (!canCreate()) return;
+    if (!canCreate() || saving) return;
+    setSaving(true);
 
     const response = await createDataset(
       name,
@@ -51,6 +54,7 @@ const NewDatasetPage: React.FC = () => {
       cleaningOptions,
       elanOptions
     );
+
     if (response.ok) {
       resetDataset();
       router.push(urls.datasets.index);
@@ -59,12 +63,12 @@ const NewDatasetPage: React.FC = () => {
       console.error(data);
       setError(data.error);
     }
+    setSaving(false);
   };
 
   return (
     <div className="container py-8 space-y-4">
       <h1 className="text-3xl">New Dataset</h1>
-      <p className="page-description">Some description</p>
 
       <ChooseDatasetName />
       <DatasetFiles />
@@ -72,11 +76,11 @@ const NewDatasetPage: React.FC = () => {
       <ChooseCleaningOptions />
 
       <div className="flex justify-end">
-        <Button onClick={save} disabled={!canCreate()}>
-          Save
+        <Button onClick={save} disabled={!canCreate() || saving}>
+          {saving && <Loader className="mr-2 animate-spin" />}
+          {saving ? 'Saving' : 'Save'}
         </Button>
       </div>
-
       {error && <p className="text-red-400">{error}</p>}
     </div>
   );

--- a/client/src/pages/train/new.tsx
+++ b/client/src/pages/train/new.tsx
@@ -35,11 +35,13 @@ import Link from 'next/link';
 import urls from 'lib/urls';
 import {createModel} from 'lib/api/models';
 import {useRouter} from 'next/router';
+import {Loader} from 'lucide-react';
 
 const NewModelPage = () => {
   const datasets = useAtomValue(datasetsAtom);
   const router = useRouter();
   const [showOptions, setShowOptions] = useState(true);
+  const [saving, setSaving] = useState(false);
 
   const modelFormSchema = z.object({
     modelName: z.string().min(1).max(20),
@@ -68,6 +70,9 @@ const NewModelPage = () => {
   });
 
   const onSubmit = async (values: z.infer<typeof modelFormSchema>) => {
+    if (saving) return;
+    setSaving(true);
+
     const {
       modelName,
       datasetName,
@@ -111,6 +116,7 @@ const NewModelPage = () => {
       const data = await response.json();
       console.error(data);
     }
+    setSaving(false);
   };
 
   return (
@@ -374,8 +380,9 @@ const NewModelPage = () => {
             </section>
           )}
 
-          <Button type="submit" className="mt-8">
-            Submit
+          <Button type="submit" className="mt-8" disabled={saving}>
+            {saving && <Loader className="mr-2 animate-spin" />}
+            {saving ? 'Saving' : 'Submit'}
           </Button>
         </form>
       </Form>

--- a/client/src/pages/transcriptions/new.tsx
+++ b/client/src/pages/transcriptions/new.tsx
@@ -1,11 +1,6 @@
 import {useAtom} from 'jotai';
 import React, {useState} from 'react';
-import {
-  modelIsLocalAtom,
-  modelLocationAtom,
-  modelsAtom,
-  transcriptionFilesAtom,
-} from 'store';
+import {modelLocationAtom, modelsAtom, transcriptionFilesAtom} from 'store';
 import {createTranscriptionJobs} from 'lib/api/transcribe';
 import ChooseModel from 'components/transcribe/ChooseModel';
 import ChooseHuggingFaceModel from 'components/transcribe/ChooseHuggingFaceModel';
@@ -16,6 +11,7 @@ import {FileType, parseFileType} from 'lib/dataset';
 import {Button} from 'components/ui/button';
 import {Tabs, TabsContent, TabsList, TabsTrigger} from 'components/ui/tabs';
 import ClientOnly from 'components/ClientOnly';
+import {Loader} from 'lucide-react';
 
 type ModelType = 'local' | 'huggingface';
 
@@ -26,8 +22,11 @@ export default function TranscribePage() {
   const [models] = useAtom(modelsAtom);
   const [error, setError] = useState('');
   const [type, setType] = useState<ModelType>('local');
+  const [saving, setSaving] = useState(false);
 
   const _createTranscriptions = async () => {
+    if (saving) return;
+    setSaving(true);
     const response = await createTranscriptionJobs(files, modelLocation);
     if (response.ok) {
       setModelLocation('');
@@ -38,6 +37,7 @@ export default function TranscribePage() {
       setError(text);
       console.error(text);
     }
+    setSaving(false);
   };
 
   const canAddTranscriptions =
@@ -78,9 +78,10 @@ export default function TranscribePage() {
       <div className="flex justify-end">
         <Button
           onClick={_createTranscriptions}
-          disabled={!canAddTranscriptions}
+          disabled={!canAddTranscriptions || saving}
         >
-          Transcribe
+          {saving && <Loader className="mr-2 animate-spin" />}
+          {saving ? 'Saving' : 'Add Transcription Jobs'}
         </Button>
       </div>
 

--- a/client/src/pages/transcriptions/view/[index].tsx
+++ b/client/src/pages/transcriptions/view/[index].tsx
@@ -17,7 +17,6 @@ import {
   CardTitle,
 } from 'components/ui/card';
 import {Label} from 'components/ui/label';
-import {Edit2, ExternalLink} from 'lucide-react';
 
 export default function ViewTranscriptionPage() {
   const [transcriptions] = useAtom(transcriptionsAtom);
@@ -120,6 +119,7 @@ export default function ViewTranscriptionPage() {
             <DownloadTranscriptionFileButton
               transcription={transcription}
               fileType="text"
+              variant="secondary"
             >
               <Download className="h-4 w-4 mr-2" />
               <span>Download Text</span>
@@ -127,6 +127,7 @@ export default function ViewTranscriptionPage() {
             <DownloadTranscriptionFileButton
               transcription={transcription}
               fileType="elan"
+              variant="secondary"
             >
               <Download className="h-4 w-4 mr-2" />
               <span>Download Elan</span>

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -246,6 +246,19 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
+"@radix-ui/react-alert-dialog@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.0.4.tgz#709d7625efadac503c6276d9e92d3449184f5e68"
+  integrity sha512-jbfBCRlKYlhbitueOAv7z74PXYeIQmWpKwm3jllsdkw7fGWNkxqP3v0nY9WmOzcPqpQuoorNtvViBgL46n5gVg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-dialog" "1.0.4"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-slot" "1.0.2"
+
 "@radix-ui/react-arrow@1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-arrow/-/react-arrow-1.0.3.tgz#c24f7968996ed934d57fe6cde5d6ec7266e1d25d"
@@ -278,6 +291,27 @@
   integrity sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==
   dependencies:
     "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-dialog@1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dialog/-/react-dialog-1.0.4.tgz#06bce6c16bb93eb36d7a8589e665a20f4c1c52c1"
+  integrity sha512-hJtRy/jPULGQZceSAP2Re6/4NpKo8im6V8P2hUqZsdFiSL8l35kYsw3qbRI6Ay5mQd2+wlLqje770eq+RJ3yZg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-dismissable-layer" "1.0.4"
+    "@radix-ui/react-focus-guards" "1.0.1"
+    "@radix-ui/react-focus-scope" "1.0.3"
+    "@radix-ui/react-id" "1.0.1"
+    "@radix-ui/react-portal" "1.0.3"
+    "@radix-ui/react-presence" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-slot" "1.0.2"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+    aria-hidden "^1.1.1"
+    react-remove-scroll "2.5.5"
 
 "@radix-ui/react-direction@1.0.1":
   version "1.0.1"


### PR DESCRIPTION
Closes #47 

Confirms deletions in the tables for datasets, models, and transcriptions, as seen below.

<img width="1257" alt="Screenshot 2023-07-25 at 1 35 13 pm" src="https://github.com/CoEDL/elpis_next/assets/24891460/ae02642c-13ad-45ae-a778-5bd93fc9cb87">
