### PR TITLE
Add loading states to UI elements when saving and downloading. 

### DIFF
--- a/client/src/components/DownloadFileButton.tsx
+++ b/client/src/components/DownloadFileButton.tsx
@@ -1,0 +1,67 @@
+import clsx from 'clsx';
+import fileDownload from 'js-file-download';
+import {Download, Loader} from 'lucide-react';
+import React, {FC, useState} from 'react';
+import {Button, ButtonProps} from './ui/button';
+
+export type DownloadFileButtonProps = {
+  downloadFile: () => Promise<Response>;
+  filename: string;
+  text?: string;
+  loadingText?: string;
+  errorText?: string;
+};
+
+const DEFAULT_ERROR_TEXT = 'Error downloading files';
+
+const DownloadFileButton: FC<DownloadFileButtonProps & ButtonProps> = ({
+  downloadFile,
+  text,
+  filename,
+  loadingText,
+  errorText,
+  disabled = false,
+  ...rest
+}) => {
+  const [downloading, setDownloading] = useState<boolean>(false);
+
+  const download = async () => {
+    if (downloading) return;
+    setDownloading(true);
+
+    const response = await downloadFile();
+    if (response.ok) {
+      const blob = await response.blob();
+      fileDownload(blob, filename);
+    } else {
+      console.error(errorText ?? DEFAULT_ERROR_TEXT);
+    }
+
+    setDownloading(false);
+  };
+
+  const Icon = downloading ? Loader : Download;
+
+  const hasText = text !== undefined && text.length > 0;
+  if (hasText) {
+    return (
+      <Button {...rest} onClick={download} disabled={disabled || downloading}>
+        <Icon className={clsx('h-4 w-4 mr-2', {'animate-spin': downloading})} />
+        {downloading ? loadingText ?? text : text}
+      </Button>
+    );
+  }
+
+  return (
+    <button {...rest} onClick={download} disabled={disabled || downloading}>
+      <Icon
+        className={clsx({
+          'animate-spin': downloading,
+          'text-gray-300': disabled,
+        })}
+      />
+    </button>
+  );
+};
+
+export default DownloadFileButton;

--- a/client/src/components/train/DatasetTable.tsx
+++ b/client/src/components/train/DatasetTable.tsx
@@ -1,14 +1,13 @@
 import {useAtom} from 'jotai';
-import fileDownload from 'js-file-download';
 import {deleteDataset, downloadDataset} from 'lib/api/datasets';
 import React from 'react';
-import {Download, Trash2} from 'lucide-react';
+import {Trash2} from 'lucide-react';
 import {datasetsAtom} from 'store';
 import DataTable, {Section} from 'components/DataTable';
 import Dataset from 'types/Dataset';
-import {Button} from 'components/ui/button';
 import ConfirmDelete from 'components/ConfirmDelete';
 import colours from 'lib/colours';
+import DownloadFileButton from 'components/DownloadFileButton';
 
 const DatasetTable: React.FC = () => {
   const [datasets, setDatasets] = useAtom(datasetsAtom);
@@ -23,16 +22,6 @@ const DatasetTable: React.FC = () => {
     }
   };
 
-  const _downloadDataset = async (datasetName: string) => {
-    const response = await downloadDataset(datasetName);
-    if (response.ok) {
-      const blob = await response.blob();
-      fileDownload(blob, datasetName + '.zip');
-    } else {
-      console.error("Couldn't download dataset :(");
-    }
-  };
-
   const sections: Section<Dataset>[] = [
     {
       name: 'Name',
@@ -43,13 +32,10 @@ const DatasetTable: React.FC = () => {
     {
       name: 'Download',
       display: dataset => (
-        <Button
-          size="icon"
-          variant="ghost"
-          onClick={() => _downloadDataset(dataset.name)}
-        >
-          <Download />
-        </Button>
+        <DownloadFileButton
+          downloadFile={() => downloadDataset(dataset.name)}
+          filename={`${dataset.name}.zip`}
+        />
       ),
     },
     {

--- a/client/src/components/train/ModelTable.tsx
+++ b/client/src/components/train/ModelTable.tsx
@@ -11,6 +11,7 @@ import Model, {TrainingStatus} from 'types/Model';
 import TrainingStatusIndicator from 'components/train/TrainingStatusIndicator';
 import DataTable, {Section} from 'components/DataTable';
 import ConfirmDelete from 'components/ConfirmDelete';
+import DownloadFileButton from 'components/DownloadFileButton';
 
 const ModelTable: React.FC = () => {
   const [models, setModels] = useAtom(modelsAtom);
@@ -33,16 +34,6 @@ const ModelTable: React.FC = () => {
       nextModel,
       ...models.slice(index + 1),
     ]);
-  };
-
-  const download = async (modelName: string) => {
-    const response = await downloadModel(modelName);
-    if (response.ok) {
-      const blob = await response.blob();
-      fileDownload(blob, modelName + '.zip');
-    } else {
-      console.error("Couldn't download model :(");
-    }
   };
 
   const _trainModel = async (index: number) => {
@@ -93,18 +84,12 @@ const ModelTable: React.FC = () => {
     {
       name: 'Download',
       display: model => (
-        <button
-          onClick={() => download(model.modelName)}
+        <DownloadFileButton
+          filename={`${model.modelName}.zip`}
+          errorText={"Couldn't download model :("}
+          downloadFile={() => downloadModel(model.modelName)}
           disabled={model.status !== TrainingStatus.Finished}
-        >
-          <Download
-            color={
-              model.status === TrainingStatus.Finished
-                ? colours.grey
-                : colours.unavailable
-            }
-          />
-        </button>
+        />
       ),
     },
     {

--- a/client/src/components/transcribe/DownloadTranscriptionFileButton.tsx
+++ b/client/src/components/transcribe/DownloadTranscriptionFileButton.tsx
@@ -1,64 +1,37 @@
 import {getElan, getText} from 'lib/api/transcribe';
-import fileDownload from 'js-file-download';
-import React, {useState} from 'react';
-import Transcription from 'types/Transcription';
-import {Button} from 'components/ui/button';
-import {Download, Loader} from 'lucide-react';
-import clsx from 'clsx';
+import React from 'react';
+import Transcription, {TranscriptionStatus} from 'types/Transcription';
+import DownloadFileButton from 'components/DownloadFileButton';
+import {ButtonProps} from 'components/ui/button';
 
 type Props = {
-  variant?: 'full' | 'icon';
+  isIcon?: boolean;
   fileType: 'elan' | 'text';
   transcription: Transcription;
 };
 
-const DownloadTranscriptionFileButton: React.FC<
-  Props & React.HTMLAttributes<HTMLButtonElement>
-> = ({fileType, variant = 'full', transcription, ...other}) => {
-  const request = fileType === 'elan' ? getElan : getText;
+const DownloadTranscriptionFileButton: React.FC<Props & ButtonProps> = ({
+  fileType,
+  transcription,
+  isIcon = false,
+  ...rest
+}) => {
   const suffix = fileType === 'elan' ? '.eaf' : '.txt';
   const fileName = transcription.audioName + suffix;
+
+  const request = fileType === 'elan' ? getElan : getText;
   const text = fileType === 'elan' ? 'Download Elan' : 'Download Text';
-  const [downloading, setDownloading] = useState(false);
-
-  const downloadFile = async () => {
-    if (downloading) return;
-    setDownloading(true);
-    const response = await request(
-      transcription.modelLocation,
-      transcription.audioName
-    );
-    if (response.ok) {
-      const blob = await response.blob();
-      fileDownload(blob, fileName);
-    }
-    setDownloading(false);
-  };
-
-  if (transcription.status !== 'finished') {
-    return null;
-  }
-
-  const Icon = downloading ? Loader : Download;
-
-  if (variant === 'icon') {
-    return (
-      <button {...other} onClick={downloadFile} disabled={downloading}>
-        <Icon className={clsx({'animate-spin': downloading})} />
-      </button>
-    );
-  }
 
   return (
-    <Button
-      variant="secondary"
-      {...other}
-      onClick={downloadFile}
-      disabled={downloading}
-    >
-      <Icon className={clsx('h-4 w-4 mr-2', {'animate-spin': downloading})} />
-      {text}
-    </Button>
+    <DownloadFileButton
+      downloadFile={() =>
+        request(transcription.modelLocation, transcription.audioName)
+      }
+      text={isIcon ? undefined : text}
+      filename={fileName}
+      disabled={transcription.status !== TranscriptionStatus.Finished}
+      {...rest}
+    />
   );
 };
 

--- a/client/src/components/transcribe/DownloadTranscriptionFileButton.tsx
+++ b/client/src/components/transcribe/DownloadTranscriptionFileButton.tsx
@@ -3,7 +3,8 @@ import fileDownload from 'js-file-download';
 import React, {useState} from 'react';
 import Transcription from 'types/Transcription';
 import {Button} from 'components/ui/button';
-import {Download} from 'lucide-react';
+import {Download, Loader} from 'lucide-react';
+import clsx from 'clsx';
 
 type Props = {
   variant?: 'full' | 'icon';
@@ -18,7 +19,6 @@ const DownloadTranscriptionFileButton: React.FC<
   const suffix = fileType === 'elan' ? '.eaf' : '.txt';
   const fileName = transcription.audioName + suffix;
   const text = fileType === 'elan' ? 'Download Elan' : 'Download Text';
-
   const [downloading, setDownloading] = useState(false);
 
   const downloadFile = async () => {
@@ -28,28 +28,35 @@ const DownloadTranscriptionFileButton: React.FC<
       transcription.modelLocation,
       transcription.audioName
     );
-    setDownloading(false);
     if (response.ok) {
       const blob = await response.blob();
       fileDownload(blob, fileName);
     }
+    setDownloading(false);
   };
 
   if (transcription.status !== 'finished') {
     return null;
   }
 
+  const Icon = downloading ? Loader : Download;
+
   if (variant === 'icon') {
     return (
       <button {...other} onClick={downloadFile} disabled={downloading}>
-        <Download />
+        <Icon className={clsx({'animate-spin': downloading})} />
       </button>
     );
   }
 
   return (
-    <Button variant="secondary" {...other} onClick={downloadFile}>
-      <Download className="h-4 w-4 mr-2" />
+    <Button
+      variant="secondary"
+      {...other}
+      onClick={downloadFile}
+      disabled={downloading}
+    >
+      <Icon className={clsx('h-4 w-4 mr-2', {'animate-spin': downloading})} />
       {text}
     </Button>
   );

--- a/client/src/components/transcribe/TranscriptionsTable.tsx
+++ b/client/src/components/transcribe/TranscriptionsTable.tsx
@@ -1,5 +1,4 @@
 import {useAtom} from 'jotai';
-import fileDownload from 'js-file-download';
 import urls from 'lib/urls';
 import {
   deleteTranscription,
@@ -8,16 +7,8 @@ import {
   transcribe,
 } from 'lib/api/transcribe';
 import colours from 'lib/colours';
-import React, {useState} from 'react';
-import {
-  AlertCircle,
-  Download,
-  Check,
-  Loader,
-  Play,
-  Trash2,
-  Eye,
-} from 'lucide-react';
+import React from 'react';
+import {AlertCircle, Check, Loader, Play, Trash2, Eye} from 'lucide-react';
 import {transcriptionsAtom} from 'store';
 import Transcription, {TranscriptionStatus} from 'types/Transcription';
 import DownloadTranscriptionFileButton from './DownloadTranscriptionFileButton';
@@ -25,10 +16,12 @@ import Link from 'next/link';
 import {Button} from 'components/ui/button';
 import DataTable, {Section} from 'components/DataTable';
 import ConfirmDelete from 'components/ConfirmDelete';
+import DownloadFileButton from 'components/DownloadFileButton';
+
+const TRANSCRIPTION_FILES_FILENAME = 'transcription_files.zip';
 
 const DatasetTable: React.FC = () => {
   const [transcriptions, setTranscriptions] = useAtom(transcriptionsAtom);
-  const [downloading, setDownloading] = useState(false);
 
   if (transcriptions.length === 0) {
     return <p>No current transcriptions!</p>;
@@ -124,19 +117,6 @@ const DatasetTable: React.FC = () => {
     }
   };
 
-  const downloadAllTranscriptions = async () => {
-    if (downloading) return;
-    setDownloading(true);
-    const response = await downloadFiles();
-    if (response.ok) {
-      const blob = await response.blob();
-      fileDownload(blob, 'transcription_files.zip');
-    } else {
-      console.error('Error downloading transcription files');
-    }
-    setDownloading(false);
-  };
-
   const sections: Section<Transcription>[] = [
     {name: 'Model Name', display: transcription => transcription.modelLocation},
     {
@@ -147,7 +127,7 @@ const DatasetTable: React.FC = () => {
       name: 'Text',
       display: transcription => (
         <DownloadTranscriptionFileButton
-          variant="icon"
+          isIcon
           transcription={transcription}
           fileType="text"
         />
@@ -157,7 +137,7 @@ const DatasetTable: React.FC = () => {
       name: 'Elan',
       display: transcription => (
         <DownloadTranscriptionFileButton
-          variant="icon"
+          isIcon
           transcription={transcription}
           fileType="elan"
         />
@@ -228,25 +208,19 @@ const DatasetTable: React.FC = () => {
             )}
             Transcribe All
           </Button>
-          <Button
+          <DownloadFileButton
+            filename={TRANSCRIPTION_FILES_FILENAME}
+            downloadFile={downloadFiles}
+            text="Download All"
             size="sm"
             variant="outline"
             disabled={
-              downloading ||
               transcriptions.filter(
                 transcription =>
                   transcription.status === TranscriptionStatus.Finished
               ).length === 0
             }
-            onClick={downloadAllTranscriptions}
-          >
-            {downloading ? (
-              <Loader className="h-4 w-4 mr-2 animate-spin" />
-            ) : (
-              <Download className="h-4 w-4 mr-2" />
-            )}
-            Download All
-          </Button>
+          />
         </div>
         <Button size="sm" variant="outline" onClick={removeAll}>
           <Trash2 className="h-4 w-4 mr-2" />

--- a/client/src/pages/datasets/new.tsx
+++ b/client/src/pages/datasets/new.tsx
@@ -16,6 +16,7 @@ import {useRouter} from 'next/router';
 import urls from 'lib/urls';
 import {isValidForDataset} from 'lib/dataset';
 import {Button} from 'components/ui/button';
+import {Loader} from 'lucide-react';
 
 const NewDatasetPage: React.FC = () => {
   const router = useRouter();
@@ -25,6 +26,7 @@ const NewDatasetPage: React.FC = () => {
   const [cleaningOptions] = useAtom(cleaningOptionsAtom);
   const [elanOptions] = useAtom(elanOptionsAtom);
   const [name] = useAtom(datasetNameAtom);
+  const [saving, setSaving] = useState(false);
 
   const resetFiles = useResetAtom(filesAtom);
   const resetElanOptions = useResetAtom(elanOptionsAtom);
@@ -43,7 +45,8 @@ const NewDatasetPage: React.FC = () => {
   };
 
   const save = async () => {
-    if (!canCreate()) return;
+    if (!canCreate() || saving) return;
+    setSaving(true);
 
     const response = await createDataset(
       name,
@@ -51,6 +54,7 @@ const NewDatasetPage: React.FC = () => {
       cleaningOptions,
       elanOptions
     );
+
     if (response.ok) {
       resetDataset();
       router.push(urls.datasets.index);
@@ -59,12 +63,12 @@ const NewDatasetPage: React.FC = () => {
       console.error(data);
       setError(data.error);
     }
+    setSaving(false);
   };
 
   return (
     <div className="container py-8 space-y-4">
       <h1 className="text-3xl">New Dataset</h1>
-      <p className="page-description">Some description</p>
 
       <ChooseDatasetName />
       <DatasetFiles />
@@ -72,11 +76,11 @@ const NewDatasetPage: React.FC = () => {
       <ChooseCleaningOptions />
 
       <div className="flex justify-end">
-        <Button onClick={save} disabled={!canCreate()}>
-          Save
+        <Button onClick={save} disabled={!canCreate() || saving}>
+          {saving && <Loader className="mr-2 animate-spin" />}
+          {saving ? 'Saving' : 'Save'}
         </Button>
       </div>
-
       {error && <p className="text-red-400">{error}</p>}
     </div>
   );

--- a/client/src/pages/train/new.tsx
+++ b/client/src/pages/train/new.tsx
@@ -35,11 +35,13 @@ import Link from 'next/link';
 import urls from 'lib/urls';
 import {createModel} from 'lib/api/models';
 import {useRouter} from 'next/router';
+import {Loader} from 'lucide-react';
 
 const NewModelPage = () => {
   const datasets = useAtomValue(datasetsAtom);
   const router = useRouter();
   const [showOptions, setShowOptions] = useState(true);
+  const [saving, setSaving] = useState(false);
 
   const modelFormSchema = z.object({
     modelName: z.string().min(1).max(20),
@@ -68,6 +70,9 @@ const NewModelPage = () => {
   });
 
   const onSubmit = async (values: z.infer<typeof modelFormSchema>) => {
+    if (saving) return;
+    setSaving(true);
+
     const {
       modelName,
       datasetName,
@@ -111,6 +116,7 @@ const NewModelPage = () => {
       const data = await response.json();
       console.error(data);
     }
+    setSaving(false);
   };
 
   return (
@@ -374,8 +380,9 @@ const NewModelPage = () => {
             </section>
           )}
 
-          <Button type="submit" className="mt-8">
-            Submit
+          <Button type="submit" className="mt-8" disabled={saving}>
+            {saving && <Loader className="mr-2 animate-spin" />}
+            {saving ? 'Saving' : 'Submit'}
           </Button>
         </form>
       </Form>

--- a/client/src/pages/transcriptions/new.tsx
+++ b/client/src/pages/transcriptions/new.tsx
@@ -1,11 +1,6 @@
 import {useAtom} from 'jotai';
 import React, {useState} from 'react';
-import {
-  modelIsLocalAtom,
-  modelLocationAtom,
-  modelsAtom,
-  transcriptionFilesAtom,
-} from 'store';
+import {modelLocationAtom, modelsAtom, transcriptionFilesAtom} from 'store';
 import {createTranscriptionJobs} from 'lib/api/transcribe';
 import ChooseModel from 'components/transcribe/ChooseModel';
 import ChooseHuggingFaceModel from 'components/transcribe/ChooseHuggingFaceModel';
@@ -16,6 +11,7 @@ import {FileType, parseFileType} from 'lib/dataset';
 import {Button} from 'components/ui/button';
 import {Tabs, TabsContent, TabsList, TabsTrigger} from 'components/ui/tabs';
 import ClientOnly from 'components/ClientOnly';
+import {Loader} from 'lucide-react';
 
 type ModelType = 'local' | 'huggingface';
 
@@ -26,8 +22,11 @@ export default function TranscribePage() {
   const [models] = useAtom(modelsAtom);
   const [error, setError] = useState('');
   const [type, setType] = useState<ModelType>('local');
+  const [saving, setSaving] = useState(false);
 
   const _createTranscriptions = async () => {
+    if (saving) return;
+    setSaving(true);
     const response = await createTranscriptionJobs(files, modelLocation);
     if (response.ok) {
       setModelLocation('');
@@ -38,6 +37,7 @@ export default function TranscribePage() {
       setError(text);
       console.error(text);
     }
+    setSaving(false);
   };
 
   const canAddTranscriptions =
@@ -78,9 +78,10 @@ export default function TranscribePage() {
       <div className="flex justify-end">
         <Button
           onClick={_createTranscriptions}
-          disabled={!canAddTranscriptions}
+          disabled={!canAddTranscriptions || saving}
         >
-          Transcribe
+          {saving && <Loader className="mr-2 animate-spin" />}
+          {saving ? 'Saving' : 'Add Transcription Jobs'}
         </Button>
       </div>
 

--- a/client/src/pages/transcriptions/view/[index].tsx
+++ b/client/src/pages/transcriptions/view/[index].tsx
@@ -17,7 +17,6 @@ import {
   CardTitle,
 } from 'components/ui/card';
 import {Label} from 'components/ui/label';
-import {Edit2, ExternalLink} from 'lucide-react';
 
 export default function ViewTranscriptionPage() {
   const [transcriptions] = useAtom(transcriptionsAtom);
@@ -120,6 +119,7 @@ export default function ViewTranscriptionPage() {
             <DownloadTranscriptionFileButton
               transcription={transcription}
               fileType="text"
+              variant="secondary"
             >
               <Download className="h-4 w-4 mr-2" />
               <span>Download Text</span>
@@ -127,6 +127,7 @@ export default function ViewTranscriptionPage() {
             <DownloadTranscriptionFileButton
               transcription={transcription}
               fileType="elan"
+              variant="secondary"
             >
               <Download className="h-4 w-4 mr-2" />
               <span>Download Elan</span>


### PR DESCRIPTION
Closes #52 
Closes #46 

- Created `DownloadFileButton` component, replaced all pre-existing buttons which tried to do the same thing.
- Display saving states for new datasets, models and transcriptions.
- Add downloading, training and saving indicators to transcriptions page.
- Add option to remove mismatched dataset files in the new datasets flow, as opposed to having to scroll through potentially thousands of pages and find the errors manually.